### PR TITLE
handle non syntactic names

### DIFF
--- a/R/data.frame.R
+++ b/R/data.frame.R
@@ -21,6 +21,8 @@ construct_idiomatic.data.frame <- function(x, keep_trailing_comma, read.table = 
     return(code)
   }
 
+  some_names_are_non_syntactic <- any(!is_syntactic(names(x)))
+  if (some_names_are_non_syntactic) x <- c(x, list(check.names = FALSE))
   construct_apply(x, fun = "data.frame", read.table = read.table, ...)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,8 +21,12 @@ pipe <- function(x, y, pipe) {
   c(x, y)
 }
 
+is_syntactic <- function(x) {
+  x == make.names(x)
+}
+
 protect <- function(name) {
-  if (name == make.names(name)) return(name)
+  if (is_syntactic(name)) return(name)
   paste0("`", name, "`")
 }
 

--- a/tests/testthat/_snaps/data.frame.new.md
+++ b/tests/testthat/_snaps/data.frame.new.md
@@ -1,0 +1,69 @@
+# data.frame
+
+    Code
+      construct(head(cars, 2))
+    Output
+      data.frame(speed = c(4, 4), dist = c(2, 10))
+    Code
+      construct(head(mtcars, 2))
+    Output
+      data.frame(
+        mpg = c(21, 21),
+        cyl = c(6, 6),
+        disp = c(160, 160),
+        hp = c(110, 110),
+        drat = c(3.9, 3.9),
+        wt = c(2.62, 2.875),
+        qsec = c(16.46, 17.02),
+        vs = c(0, 0),
+        am = c(1, 1),
+        gear = c(4, 4),
+        carb = c(4, 4)
+      ) |>
+        structure(row.names = c("Mazda RX4", "Mazda RX4 Wag"))
+    Code
+      construct(tail(cars, 2))
+    Output
+      data.frame(speed = c(24, 25), dist = c(120, 85)) |>
+        structure(row.names = 49:50)
+    Code
+      construct(head(cars, 2), read.table = TRUE)
+    Output
+      read.table(header = TRUE, text = "
+      speed dist
+      4.    2.
+      4.    10.
+      ")
+    Code
+      construct(transform(mtcars[1:2, 1:2], chr = c("a", "b"), int = 1:2),
+      read.table = TRUE)
+    Output
+      read.table(header = TRUE, text = "
+                      mpg cyl chr int
+      'Mazda RX4'     21. 6.  a   1
+      'Mazda RX4 Wag' 21. 6.  b   2
+      ") |>
+        structure(row.names = c("Mazda RX4", "Mazda RX4 Wag"))
+    Code
+      construct(head(iris, 2), read.table = TRUE)
+    Output
+      data.frame(
+        Sepal.Length = c(5.1, 4.9),
+        Sepal.Width = c(3.5, 3),
+        Petal.Length = c(1.4, 1.4),
+        Petal.Width = c(0.2, 0.2),
+        Species = factor(c("setosa", "setosa"), levels = c("setosa", "versicolor", "virginica"))
+      )
+    Code
+      construct(as.data.frame(tibble::tibble(a = 1:2, b = list(3, 4))))
+    Output
+      as.data.frame(tibble::tibble(a = 1:2, b = list(3, 4)))
+    Code
+      construct(as.data.frame(tibble::tibble(a = 1:2, b = tibble::tibble(x = 3:4))))
+    Output
+      as.data.frame(tibble::tibble(a = 1:2, b = tibble::tibble(x = 3:4)))
+    Code
+      construct(data.frame(a = 1, `a a` = 2, check.names = FALSE))
+    Output
+      data.frame(a = 1, `a a` = 2, check.names = FALSE)
+

--- a/tests/testthat/test-data.frame.R
+++ b/tests/testthat/test-data.frame.R
@@ -15,5 +15,7 @@ test_that("data.frame", {
     # handle list  and df cols
     construct(as.data.frame(tibble::tibble(a = 1:2, b = list(3, 4))))
     construct(as.data.frame(tibble::tibble(a = 1:2, b = tibble::tibble(x = 3:4))))
+    # handle non syntactic names
+    construct(data.frame(a=1, `a a` = 2, check.names = FALSE))
   })
 })


### PR DESCRIPTION
data.frame() messes with non syntactic names by default unless we set check.names to `FALSE`.
fixed by this PR