### PR TITLE
handle na numerics

### DIFF
--- a/R/numeric.R
+++ b/R/numeric.R
@@ -34,11 +34,14 @@ construct_idiomatic.double <- function(x, max_atomic = NULL, ...) {
     )
     return(code)
   }
-  construct_apply(vapply(x, format_flex, character(1)), "c", new_line = FALSE, language = TRUE, ...)
+  construct_apply(vapply(x, format_flex, character(1), all_na = all(is.na(x))), "c", new_line = FALSE, language = TRUE, ...)
 }
 
-format_flex <- function(x) {
+format_flex <- function(x, all_na) {
   formatted <- format(x, digits = 16)
+  if (formatted == "NA") {
+    if (all_na) return("NA_real_") else return("NA")
+  }
   if (as.numeric(formatted) == x) return(formatted)
   format(x, digits = 22)
 }

--- a/tests/testthat/test-data.frame.R
+++ b/tests/testthat/test-data.frame.R
@@ -17,5 +17,16 @@ test_that("data.frame", {
     construct(as.data.frame(tibble::tibble(a = 1:2, b = tibble::tibble(x = 3:4))))
     # handle non syntactic names
     construct(data.frame(a=1, `a a` = 2, check.names = FALSE))
+    # handle nas
+    construct(data.frame(
+      a= c(NA, NA),
+      b= c(TRUE, NA),
+      c= c(NA_character_, NA),
+      d= c("a", NA),
+      e= c(NA_integer_, NA),
+      f= c(1L, NA),
+      g= c(NA_real_, NA),
+      h= c(1, NA)
+    ))
   })
 })


### PR DESCRIPTION
We have a special way of handling numerics and it wasn't robust to NAs. Now it is.
We are consistent with other types in that we use explicit `NA_real_` only if a vector contains only NAs