### PR TITLE
Improve function support

### DIFF
--- a/R/function.R
+++ b/R/function.R
@@ -1,5 +1,7 @@
 #' @export
-construct_idiomatic.function <- function(x, pipe, max_body = NULL, ...) {
+construct_idiomatic.function <- function(
+    x, pipe, max_body = NULL, function.as.function = FALSE,
+    function.zap_srcref = FALSE, function.construct_env = FALSE, one_liner = FALSE, ...) {
   x_lst <- as.list(x)
   body_lng <- x_lst[[length(x_lst)]]
   if (!is.null(max_body)) {
@@ -7,16 +9,54 @@ construct_idiomatic.function <- function(x, pipe, max_body = NULL, ...) {
       x_lst[[length(x_lst)]] <- as.call(c(head(as.list(body_lng), max_body + 1), quote(...)))
     }
   }
-  # rlang::expr_deparse changes the body by putting parentheses around f <- (function(){})
-  # so we must use regular deparse
-  fun_lst <- lapply(x_lst, deparse)
+  if (!function.as.function) {
+    # FIXME: we should use the srcref
+    code <- deparse(as.function(x_lst))
+    if (length(code) == 2) code <- paste(code[1], code[2])
+    if (function.construct_env || function.zap_srcref) {
+      code[1] <- paste0("(", code[1])
+      n <- length(code)
+      code[n] <- paste0(code[n], ")")
+    }
+    if (function.construct_env) {
+      envir_code <- construct_apply(
+        list(environment(x)),
+        'match.fun("environment<-")',
+        function.as.function = function.as.function,
+        function.zap_srcref = function.zap_srcref,
+        function.construct_env = function.construct_env,
+        one_liner = one_liner,
+        ...)
+      code <- pipe(code, envir_code, pipe, one_liner)
+    }
+  } else {
+    # rlang::expr_deparse changes the body by putting parentheses around f <- (function(){})
+    # so we must use regular deparse
+    fun_lst <- lapply(x_lst, deparse)
+    x_arg <- construct_apply(
+      fun_lst, "alist", language = TRUE, pipe = pipe, max_body = max_body,
+                             function.as.function = function.as.function, function.zap_srcref = function.zap_srcref,
+                             function.construct_env = function.construct_env, one_liner = one_liner, ...)
+    if (function.construct_env) {
+      envir_arg <- construct_raw(environment(x), pipe = pipe, max_body = max_body, ...)
+      code <- construct_apply(
+        list(x_arg, envir = envir_arg), "as.function", language = TRUE,
+        function.as.function = function.as.function, function.zap_srcref = function.zap_srcref,
+        function.construct_env = function.construct_env, one_liner = one_liner, ...)
+    } else {
+      code <- construct_apply(
+        list(x_arg), "as.function", language = TRUE,
+        function.as.function = function.as.function, function.zap_srcref = function.zap_srcref,
+        function.construct_env = function.construct_env, one_liner = one_liner, ...)
+    }
+  }
 
-  # as.function creates a srcref if the body starts with `{` so we remove it
-  srcrefed <- is.call(body_lng) && identical(body_lng[[1]], as.symbol("{"))
-  x_arg <- construct_apply(fun_lst, "alist", language = TRUE, pipe = pipe, max_body = max_body, ...)
-  envir_arg <- construct_raw(environment(x), pipe = pipe, max_body = max_body, ...)
-  code <- construct_apply(list(x_arg, envir = envir_arg), "as.function", language = TRUE, ...)
-  if (srcrefed) pipe(code, "rlang::zap_srcref()", pipe) else code
+  if (function.zap_srcref) {
+    # a srcref is created if the body starts with `{` so we remove it
+    srcrefed <- is.call(body_lng) && identical(body_lng[[1]], as.symbol("{"))
+    if (srcrefed) code <- pipe(code, "rlang::zap_srcref()", pipe, one_liner)
+  }
+  code
 }
 
 #' @export

--- a/tests/testthat/_snaps/function.md
+++ b/tests/testthat/_snaps/function.md
@@ -1,15 +1,89 @@
 # function
 
     Code
-      construct(as.function(alist(x = , x), .GlobalEnv))
+      construct(as.function(alist(x = , x), .GlobalEnv), check = FALSE)
+    Output
+      function(x) x
+    Code
+      construct(as.function(alist(x = , {
+        x
+      }), .GlobalEnv), check = FALSE)
+    Output
+      function(x) {
+        x
+      }
+    Code
+      construct(as.function(alist(x = , x), .GlobalEnv), function.construct_env = TRUE)
+    Output
+      (function(x) x) |>
+        match.fun("environment<-")(.GlobalEnv)
+    Code
+      construct(as.function(alist(x = , x), .GlobalEnv), function.zap_srcref = TRUE,
+      check = FALSE)
+    Output
+      (function(x) x)
+    Code
+      construct(as.function(alist(x = , {
+        x
+      }), .GlobalEnv), function.zap_srcref = TRUE, check = FALSE)
+    Output
+      (function(x) {
+        x
+      }) |>
+        rlang::zap_srcref()
+    Code
+      construct(as.function(alist(x = , x), .GlobalEnv), function.as.function = TRUE,
+      check = FALSE)
+    Output
+      as.function(alist(x = , x))
+    Code
+      construct(as.function(alist(x = , {
+        x
+      }), .GlobalEnv), function.as.function = TRUE, check = FALSE)
+    Output
+      as.function(
+        alist(
+          x = ,
+          {
+            x
+          }
+        )
+      )
+    Code
+      construct(as.function(alist(x = , x), .GlobalEnv), function.as.function = TRUE,
+      function.construct_env = TRUE)
     Output
       as.function(alist(x = , x), envir = .GlobalEnv)
     Code
-      construct(identity)
+      construct(as.function(alist(x = , x), .GlobalEnv), function.as.function = TRUE,
+      function.zap_srcref = TRUE, check = FALSE)
     Output
-      as.function(alist(x = , x), envir = .BaseNamespaceEnv)
+      as.function(alist(x = , x))
     Code
-      construct(setNames)
+      construct(as.function(alist(x = , {
+        x
+      }), .GlobalEnv), function.as.function = TRUE, function.zap_srcref = TRUE,
+      check = FALSE)
+    Output
+      as.function(
+        alist(
+          x = ,
+          {
+            x
+          }
+        )
+      ) |>
+        rlang::zap_srcref()
+    Code
+      construct(setNames, function.construct_env = TRUE)
+    Output
+      (function(object = nm, nm) {
+        names(object) <- nm
+        object
+      }) |>
+        match.fun("environment<-")(asNamespace("stats"))
+    Code
+      construct(setNames, function.as.function = TRUE, function.construct_env = TRUE)
     Output
       as.function(
         alist(
@@ -21,20 +95,11 @@
           }
         ),
         envir = asNamespace("stats")
-      ) |>
-        rlang::zap_srcref()
+      )
     Code
-      construct(setNames, max_body = 0)
+      construct(setNames, max_body = 0, check = FALSE)
     Output
-      as.function(
-        alist(
-          object = nm,
-          nm = ,
-          {
-            ...
-          }
-        ),
-        envir = asNamespace("stats")
-      ) |>
-        rlang::zap_srcref()
+      function(object = nm, nm) {
+        ...
+      }
 

--- a/tests/testthat/test-function.R
+++ b/tests/testthat/test-function.R
@@ -1,13 +1,21 @@
 test_that("function", {
   expect_snapshot({
-    # lambda function
-    construct(as.function(alist(x=, x), .GlobalEnv))
-    # function from recognizable namespace, no srcref when no {
-    construct(identity)
-    # with src_ref
-    construct(setNames)
+    construct(as.function(alist(x=, x), .GlobalEnv), check = FALSE)
+    construct(as.function(alist(x=, {x}), .GlobalEnv), check = FALSE)
+    construct(as.function(alist(x=, x), .GlobalEnv), function.construct_env = TRUE)
+    construct(as.function(alist(x=, x), .GlobalEnv), function.zap_srcref = TRUE, check = FALSE)
+    construct(as.function(alist(x=, {x}), .GlobalEnv), function.zap_srcref = TRUE, check = FALSE)
+
+    construct(as.function(alist(x=, x), .GlobalEnv), function.as.function = TRUE, check = FALSE)
+    construct(as.function(alist(x=, {x}), .GlobalEnv), function.as.function = TRUE, check = FALSE)
+    construct(as.function(alist(x=, x), .GlobalEnv), function.as.function = TRUE, function.construct_env = TRUE)
+    construct(as.function(alist(x=, x), .GlobalEnv), function.as.function = TRUE, function.zap_srcref = TRUE, check = FALSE)
+    construct(as.function(alist(x=, {x}), .GlobalEnv), function.as.function = TRUE, function.zap_srcref = TRUE, check = FALSE)
+
+    construct(setNames, function.construct_env = TRUE)
+    construct(setNames, function.as.function = TRUE, function.construct_env = TRUE)
     # with max_body
-    construct(setNames, max_body = 0)
+    construct(setNames, max_body = 0, check = FALSE)
   })
 })
 


### PR DESCRIPTION
We now define function the standard `function() {}` way. This means by default we don't attempt to reproduce the environment nor the src_ref