### PR TITLE
make match2() more robust re envs

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -47,7 +47,8 @@ match2 <- function(needle, haystack) {
   attributes(needle) <- NULL
   # like identical but ignoring attributes of haystack elements and their environment-ness
   identical2 <- function(x, needle) {
-    if (is.environment(x)) x <- as.list(x)
+    # as.list() doesn't work on environments with a S3 class excluding "environment"
+    if (is.environment(x)) x <- as.list.environment(x)
     attributes(x) <- NULL
     identical(x, needle)
   }

--- a/tests/testthat/_snaps/dots.new.md
+++ b/tests/testthat/_snaps/dots.new.md
@@ -1,0 +1,25 @@
+# dots
+
+    Code
+      dots1 <- local((function(...) environment()$...)(a = x, y))
+      construct(dots1)
+    Output
+      evalq(
+        (function(...) environment()$...)(a = x, y),
+        envir = new.env(parent = asNamespace("constructive"))
+      )
+    Code
+      f <- (function(...) {
+        y <- 1
+        g(y = y, ...)
+      })
+      g <- (function(...) environment()$...)
+      x <- 1
+      dots2 <- local(f(x = x))
+      construct(dots2)
+    Output
+      rlang::inject((function(...) environment()$...)(!!!list(
+        y = rlang::as_quosure(~y, list2env(list(y = 1), parent = asNamespace("constructive"))),
+        x = rlang::as_quosure(~x, new.env(parent = asNamespace("constructive")))
+      )))
+

--- a/tests/testthat/_snaps/quosure.new.md
+++ b/tests/testthat/_snaps/quosure.new.md
@@ -1,0 +1,7 @@
+# quosure
+
+    Code
+      construct(rlang::new_quosure(quote(x)))
+    Output
+      rlang::as_quosure(~x, new.env(parent = asNamespace("constructive")))
+

--- a/tests/testthat/_snaps/quosures.new.md
+++ b/tests/testthat/_snaps/quosures.new.md
@@ -1,0 +1,29 @@
+# quosures
+
+    Code
+      construct(rlang::new_quosures(list(rlang::new_quosure(quote(x)), rlang::new_quosure(
+        quote(x), new.env()))))
+    Message
+      {constructive} couldn't create code that reproduces perfectly the input
+      i Call `construct_issues()` to inspect the last issues
+    Output
+      rlang::as_quosures(
+        list(
+          rlang::as_quosure(~x, new.env(parent = asNamespace("constructive"))),
+          rlang::as_quosure(~x, new.env(parent = asNamespace("constructive")))
+        )
+      )
+    Code
+      construct(rlang::new_quosures(list(a = rlang::new_quosure(quote(x)), rlang::new_quosure(
+        quote(x), new.env()))))
+    Message
+      {constructive} couldn't create code that reproduces perfectly the input
+      i Call `construct_issues()` to inspect the last issues
+    Output
+      rlang::as_quosures(
+        list(
+          a = rlang::as_quosure(~x, new.env(parent = asNamespace("constructive"))),
+          rlang::as_quosure(~x, new.env(parent = asNamespace("constructive")))
+        )
+      )
+


### PR DESCRIPTION
by using as.list.environment() rather than as.list()