### PR TITLE
handle conflicts in data

### DIFF
--- a/R/constructive.R
+++ b/R/constructive.R
@@ -125,18 +125,23 @@ print.constructive <- function(x, ...) {
 }
 
 preprocess_data <- function(data, main = TRUE) {
-  if (is.character(data) && length(data) == 1) return(namespace_as_list(data))
+  if (is.character(data) && length(data) == 1) return(namespace_as_list(data, main = main))
   if (is.environment(data)) return(as.list(data))
   # recurse into unnamed elements
   nms <- rlang::names2(data)
   named_elts <-  data[nms != ""]
   unnamed_elts <-  data[nms == ""]
   objs <- c(named_elts, do.call(c, lapply(unnamed_elts, preprocess_data, main = FALSE)))
-  if (main & anyDuplicated(names(objs))) {
-    dupes <- names(objs)[duplicated(names(objs))]
-    msg <- "`data` must contain must one definition per name"
-    info <- sprintf("Found duplicate definitions for %s", collapse(dupes, quote = "`"))
-    abort(c(msg, x = info), call = parent.frame())
+  if (main) {
+    if (anyDuplicated(names(objs))) {
+      dupes <- names(objs)[duplicated(names(objs))]
+      msg <- "`data` must contain must one definition per name"
+      info <- sprintf("Found duplicate definitions for %s", collapse(dupes, quote = "`"))
+      abort(c(msg, x = info), call = parent.frame())
+    }
+    short_nms <- sub("^[^:]+::", "", names(objs))
+    dupes_lgl <- duplicated(short_nms) | duplicated(short_nms, fromLast = TRUE)
+    names(objs)[!dupes_lgl] <- short_nms[!dupes_lgl]
   }
   objs
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -35,7 +35,7 @@ namespace_as_list <- function(pkg) {
   ns <- asNamespace(pkg)
   if (pkg == "base") return(as.list(ns))
   c(
-    mget(getNamespaceExports(ns), ns, inherits = TRUE, ifnotfound = NULL),
+    mget(getNamespaceExports(ns), ns, inherits = TRUE, ifnotfound = list(NULL)),
     as.list(.getNamespaceInfo(ns, "lazydata"))
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -56,3 +56,28 @@ match2 <- function(needle, haystack) {
   if (length(ind)) ind <- ind[[1]]
   ind
 }
+
+
+# adapted from glue::glue_collapse
+collapse <- function (x, sep = ",", width = 80, last = " and ", quote = "") {
+  if (length(x) == 0) {
+    return(character())
+  }
+  if (any(is.na(x))) {
+    return(NA_character_)
+  }
+  x <- paste0(quote, x, quote)
+  if (nzchar(last) && length(x) > 1) {
+    res <- collapse(x[seq(1, length(x) - 1)], sep = sep, width = Inf, last = "")
+    return(collapse(paste0(res, last, x[length(x)]), width = width))
+  }
+  x <- paste0(x, collapse = sep)
+  if (width < Inf) {
+    x_width <- nchar(x, "width")
+    too_wide <- x_width > width
+    if (too_wide) {
+      x <- paste0(substr(x, 1, width - 3), "...")
+    }
+  }
+  x
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -31,14 +31,16 @@ protect <- function(name) {
   ifelse(is_syntactic(name), name, paste0("`", name, "`"))
 }
 
-namespace_as_list <- function(pkg) {
+namespace_as_list <- function(pkg, main) {
   ns <- asNamespace(pkg)
   if (pkg == "base") return(as.list(ns))
   objs <- c(
     mget(getNamespaceExports(ns), ns, inherits = TRUE, ifnotfound = list(NULL)),
     as.list(.getNamespaceInfo(ns, "lazydata"))
   )
-  names(objs) <- paste0(pkg, "::", names(objs))
+  if (!main) {
+    names(objs) <- paste0(pkg, "::", names(objs))
+  }
   objs
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -44,13 +44,15 @@ namespace_as_list <- function(pkg) {
 match2 <- function(needle, haystack) {
   # ignore attributes of needle and its environment-ness
   if (is.environment(needle)) needle <- as.list(needle)
-  attributes(needle) <- NULL
+  attributes(needle) <- attributes(needle)["names"]
   # like identical but ignoring attributes of haystack elements and their environment-ness
   identical2 <- function(x, needle) {
     # as.list() doesn't work on environments with a S3 class excluding "environment"
     if (is.environment(x)) x <- as.list.environment(x)
-    attributes(x) <- NULL
+    attributes(x) <- attributes(x)["names"]
     identical(x, needle)
   }
-  which(vapply(haystack, identical2, needle, FUN.VALUE = logical(1)))
+  ind <- which(vapply(haystack, identical2, needle, FUN.VALUE = logical(1)))
+  if (length(ind)) ind <- ind[[1]]
+  ind
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -34,10 +34,12 @@ protect <- function(name) {
 namespace_as_list <- function(pkg) {
   ns <- asNamespace(pkg)
   if (pkg == "base") return(as.list(ns))
-  c(
+  objs <- c(
     mget(getNamespaceExports(ns), ns, inherits = TRUE, ifnotfound = list(NULL)),
     as.list(.getNamespaceInfo(ns, "lazydata"))
   )
+  names(objs) <- paste0(pkg, "::", names(objs))
+  objs
 }
 
 # much faster than match()

--- a/tests/testthat/_snaps/others.md
+++ b/tests/testthat/_snaps/others.md
@@ -16,6 +16,15 @@
       construct(list(letters), data = list(foo = letters))
     Output
       list(foo)
+    Code
+      construct(list(letters), data = list(foo = letters, bar = letters))
+    Output
+      list(foo)
+    Code
+      construct(list(data.table::first, dplyr::first, dplyr::select), data = c(
+        "dplyr", "data.table"))
+    Output
+      list(data.table::first, dplyr::first, select)
 
 # noquote is supported
 

--- a/tests/testthat/test-others.R
+++ b/tests/testthat/test-others.R
@@ -4,7 +4,16 @@ test_that("The data arg works", {
     construct(list(iris), data = "datasets")
     construct(list(letters), data = baseenv())
     construct(list(letters), data = list(foo = letters))
+    # if two choices, pick first
+    construct(list(letters), data = list(foo = letters, bar = letters))
+    # use namespace notation only if ambiguous
+    construct(list(data.table::first, dplyr::first, dplyr::select), data = c("dplyr", "data.table"))
   })
+
+  expect_error(
+    construct(1, data = list(foo = 2, foo = 3)),
+    "duplicate"
+  )
 })
 
 test_that("noquote is supported", {


### PR DESCRIPTION
Closes #79

``` r
constructive::construct(list(pryr::partial, purrr::partial, purrr::map, purrr::map_dbl), data = c("pryr", "purrr", list(map = 1)))
#> list(pryr::partial, purrr::partial, purrr::map, map_dbl)

constructive::construct(list(1, 2), data = list(list(x=1), list(x=2)))
#> Error in `constructive::construct()`:
#> ! `data` must contain must one definition per name
#> ✖ Found duplicate definitions for `x`

#> Backtrace:
#>     ▆
#>  1. └─constructive::construct(list(1, 2), data = list(list(x = 1), list(x = 2)))
#>  2.   └─constructive:::preprocess_data(data) at constructive/R/constructive.R:65:2
#>  3.     └─rlang::abort(c(msg, x = info), call = parent.frame()) at constructive/R/constructive.R:141:6
```

<sup>Created on 2022-11-06 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>