### PR TITLE
predefine environments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,8 @@ Suggests:
     data.table,
     vctrs,
     tibble,
-    prettycode
+    prettycode,
+    tidyselect
 URL: https://github.com/cynkra/constructive,
     https://cynkra.github.io/constructive
 BugReports: https://github.com/cynkra/constructive/issues

--- a/R/constructive.R
+++ b/R/constructive.R
@@ -48,6 +48,7 @@
 construct <- function(x, ..., data = NULL, pipe = c("base", "magrittr"), check = NULL,
                       ignore_srcref = TRUE, ignore_attr = FALSE, ignore_function_env = FALSE, ignore_formula_env = FALSE, one_liner = FALSE,
                       template = getOption("constructive_opts_template")) {
+  # reset globals
   globals$predefinition <- character()
   globals$envs <- data.frame(hash = character(), name = character())
 

--- a/R/environment.R
+++ b/R/environment.R
@@ -54,7 +54,7 @@
 #'   attempt to recreate all parent environments until a known environment is found,
 #'   if `FALSE` (the default) we will use `topenv()` to find a known ancestor to set as
 #'   the parent.
-#' @param predefine Boolean. Whether to define environments first. `constructor` and `recurse`
+#' @param predefine Boolean. Whether to define environments first. If `TRUE` `constructor` and `recurse`
 #'   are ignored. This is the most faithful approach as it circumvents the circularity
 #'   and recursivity issues of available constructors. The caveat is that the created code
 #'   won't be a single call and will create objects in the workspace.

--- a/R/environment.R
+++ b/R/environment.R
@@ -54,10 +54,14 @@
 #'   attempt to recreate all parent environments until a known environment is found,
 #'   if `FALSE` (the default) we will use `topenv()` to find a known ancestor to set as
 #'   the parent.
+#' @param predefine Boolean. Whether to define environments first. `constructor` and `recurse`
+#'   are ignored. This is the most faithful approach as it circumvents the circularity
+#'   and recursivity issues of available constructors. The caveat is that the created code
+#'   won't be a single call and will create objects in the workspace.
 #'
 #' @return An object of class <constructive_options/constructive_options_environment>
 #' @export
-opts_environment <- function(constructor = c("list2env", "as.environment", "new.env", "topenv", "new_environment"), ..., recurse = FALSE) {
+opts_environment <- function(constructor = c("list2env", "as.environment", "new.env", "topenv", "new_environment"), ..., recurse = FALSE, predefine = FALSE) {
   combine_errors(
     constructor <- rlang::arg_match(constructor),
     ellipsis::check_dots_empty(),
@@ -66,10 +70,9 @@ opts_environment <- function(constructor = c("list2env", "as.environment", "new.
 
   structure(
     class = c("constructive_options", "constructive_options_environment"),
-    list(constructor = constructor, recurse = recurse)
+    list(constructor = constructor, recurse = recurse, predefine = predefine)
   )
 }
-
 
 #' @export
 construct_idiomatic.environment <- function(x, ..., pipe = "base", one_liner = FALSE) {
@@ -84,6 +87,17 @@ construct_idiomatic.environment <- function(x, ..., pipe = "base", one_liner = F
   opts <- fetch_opts("environment", ...)
   constructor <- opts$constructor
   recurse <- opts$recurse
+  predefine <- opts$predefine
+
+  if (predefine) {
+    globals$special_envs <-  c(row.names(installed.packages()), search(), "R_EmptyEnv", "R_GlobalEnv")
+    # construct only if not found
+    if (!environmentName(x) %in% globals$special_envs) {
+      code <- update_predefinition(x, ..., pipe = pipe, one_liner = one_liner)
+      return(code)
+    }
+  }
+
 
   if (identical(x, baseenv())) return('baseenv()')
   if (identical(x, emptyenv())) return('emptyenv()')
@@ -143,9 +157,62 @@ construct_idiomatic.environment <- function(x, ..., pipe = "base", one_liner = F
 
 #' @export
 repair_attributes.environment <- function(x, code, ..., pipe ="base") {
+  opts <- fetch_opts("environment", ...)
   repair_attributes_impl(
     x, code, ...,
     pipe = pipe,
-    ignore = c("name", "path")
+    ignore = c("name", "path",  if(opts$predefine) "class")
   )
+}
+
+update_predefinition <- function(env, ...) {
+  # construct parent before constructing env
+  parent_code <- construct_raw(parent.env(env), ...)
+  # if env was already constructed (recorded in globals$env), just return its name
+  hash <- format(env)
+  if (hash %in% globals$envs$hash) {
+    return(globals$envs$name[hash == globals$envs$hash][[1]])
+  }
+  # create a new name, incrementing count
+  env_name <- sprintf("..env.%s..", nrow(globals$envs) + 1)
+  # update globals$envs with new row (hash + variable name)
+  globals$envs <- rbind(globals$envs, data.frame(hash = hash, name = env_name))
+  # initialize with new.env(), repairing attributes
+  code <- sprintf("new.env(parent = %s)", parent_code)
+  # hack: we use  opts_environment(predefine = FALSE) to switch on attribute reparation just there
+  code <- repair_attributes.environment(env, code, opts_environment(predefine = FALSE), ...)
+  code[[1]] <- sprintf("%s <- %s", env_name, code[[1]])
+  # update predefinitions with env definition
+  globals$predefinition <- c(
+    globals$predefinition,
+    code
+  )
+  # build non environment objects of env above
+  for(nm in names(env)) {
+    obj <- env[[nm]]
+    if (!is.environment(obj)) {
+      nm <- protect(nm)
+      # this defines the objects as a side effect
+      obj_code <- construct_raw(obj, ...)
+      obj_code[[1]] <- sprintf("%s$%s <- %s", env_name, nm, obj_code[[1]])
+      globals$predefinition <- c(
+        globals$predefinition,
+        obj_code
+      )
+    }
+  }
+
+  # build environment objects of env above
+  for(nm in names(env)) {
+    obj <- env[[nm]]
+    if (is.environment(obj)) {
+      nm <- protect(nm)
+      sub_env_name <- construct_raw(obj, ...) # this will also print code
+      globals$predefinition <- c(
+        globals$predefinition,
+        sprintf("%s$%s <- %s", env_name, nm, sub_env_name)
+      )
+    }
+  }
+  env_name
 }

--- a/man/opts_environment.Rd
+++ b/man/opts_environment.Rd
@@ -7,7 +7,8 @@
 opts_environment(
   constructor = c("list2env", "as.environment", "new.env", "topenv", "new_environment"),
   ...,
-  recurse = FALSE
+  recurse = FALSE,
+  predefine = FALSE
 )
 }
 \arguments{

--- a/man/opts_environment.Rd
+++ b/man/opts_environment.Rd
@@ -20,6 +20,11 @@ opts_environment(
 attempt to recreate all parent environments until a known environment is found,
 if \code{FALSE} (the default) we will use \code{topenv()} to find a known ancestor to set as
 the parent.}
+
+\item{predefine}{Boolean. Whether to define environments first. If \code{TRUE} \code{constructor} and \code{recurse}
+are ignored. This is the most faithful approach as it circumvents the circularity
+and recursivity issues of available constructors. The caveat is that the created code
+won't be a single call and will create objects in the workspace.}
 }
 \value{
 An object of class <constructive_options/constructive_options_environment>

--- a/tests/testthat/_snaps/environment.md
+++ b/tests/testthat/_snaps/environment.md
@@ -103,4 +103,41 @@
       i Call `construct_issues()` to inspect the last issues
     Output
       as.environment(list(y = 2))
+    Code
+      construct(tidyselect::peek_vars, opts_environment(predefine = TRUE),
+      opts_function(environment = TRUE))
+    Output
+      ..env.1.. <- new.env(parent = asNamespace("tidyselect"))
+      ..env.1..$what <- "selected"
+      (function(..., fn = NULL) {
+        if (!missing(...)) {
+          check_dots_empty()
+        }
+        x <- vars_env[[what]]
+        if (is_null(x)) {
+          if (is_null(fn)) {
+            fn <- "Selection helpers"
+          } else {
+            fn <- glue::glue("`{fn}()`")
+          }
+          cli::cli_abort(
+            c("{fn} must be used within a *selecting* function.", i = "See {peek_vars_link()} for details."),
+            call = NULL
+          )
+        }
+        x
+      }) |>
+        match.fun("environment<-")(..env.1..)
+    Code
+      evalq({
+        e <- new.env()
+        e$f <- e
+        foo <- evalq(~a, e)
+        construct(foo, opts_environment(predefine = TRUE), opts_formula(environment = TRUE))
+      }, .GlobalEnv)
+    Output
+      ..env.1.. <- new.env(parent = .GlobalEnv)
+      ..env.1..$f <- ..env.1..
+      (~a) |>
+        structure(.Environment = ..env.1..)
 

--- a/tests/testthat/test-environment.R
+++ b/tests/testthat/test-environment.R
@@ -28,5 +28,13 @@ test_that("environment", {
     construct(e2, opts_environment(constructor = "new.env"))
     construct(e2, opts_environment(constructor = "topenv"))
     construct(e2, opts_environment(constructor = "as.environment"))
+    construct(tidyselect::peek_vars, opts_environment(predefine = TRUE), opts_function(environment = TRUE))
+    # circularity
+    evalq({
+    e <- new.env()
+    e$f <- e
+    foo <- evalq(~a, e)
+    construct(foo, opts_environment(predefine = TRUE), opts_formula(environment = TRUE))
+    }, .GlobalEnv)
   })
 })


### PR DESCRIPTION
Closes #76 

This solves issues of circularity but this breaks the principle of having a single call, and by doing so the constructed code creates variables

```
e <- new.env()
e$f <- e
foo <- evalq(~a, e)
construct(foo, opts_environment(predefine = TRUE), opts_formula(environment = TRUE))
#> .env.1.. <- new.env(parent = .GlobalEnv)
#> ..env.1..$f <- ..env.1..
#> (~a) |>
#>   structure(.Environment = ..env.1..)
```