### PR TITLE
chore: Use natural spacing in `expr()` calls

### DIFF
--- a/R/construct-helpers.R
+++ b/R/construct-helpers.R
@@ -50,7 +50,7 @@ process_data <- function(data, main = TRUE) {
 
 try_construct <- function(x, ...) {
   # deal early with special case x = quote(expr=)
-  if (identical(x, quote(expr=))) return("quote(expr=)")
+  if (identical(x, quote(expr=))) return("quote(expr = )")
   caller <- caller_env()
   rlang::try_fetch(.cstr_construct(x, ...), error = function(e) {
     #nocov start

--- a/R/environment_utils.R
+++ b/R/environment_utils.R
@@ -93,7 +93,7 @@ update_predefinition <- function(envir, ...) {
   for (nm in names(envir)) {
     obj <- envir[[nm]]
     if (missing(obj)) {
-      obj_code <- sprintf("%s$%s <- quote(expr=)", env_name, nm)
+      obj_code <- sprintf("%s$%s <- quote(expr = )", env_name, nm)
       globals$predefinition <- c(
         globals$predefinition,
         obj_code
@@ -114,7 +114,7 @@ update_predefinition <- function(envir, ...) {
   for (nm in names(envir)) {
     obj <- envir[[nm]]
     if (missing(obj)) {
-      obj_code <- sprintf("%s$%s <- quote(expr=)", env_name, nm)
+      obj_code <- sprintf("%s$%s <- quote(expr = )", env_name, nm)
       globals$predefinition <- c(
         globals$predefinition,
         obj_code

--- a/R/s3-language.R
+++ b/R/s3-language.R
@@ -36,7 +36,7 @@ is_corrupted_language <- function(x) {
 }
 
 constructors$language$default <- function(x, ..., one_liner = FALSE) {
-  if (identical(x, quote(expr=))) return("quote(expr=)")
+  if (identical(x, quote(expr=))) return("quote(expr = )")
   x_stripped <- x
   attributes(x_stripped) <- NULL
 


### PR DESCRIPTION
Part of #49.