### PR TITLE
Adapt ggplot

### DIFF
--- a/R/s3-ggplot2-theme.R
+++ b/R/s3-ggplot2-theme.R
@@ -5,7 +5,7 @@
   args$validate <- if (!attr(x, "validate")) FALSE
   if (attr(x, "complete")) {
     code <- guess_complete_theme(x, ...)
-    if (!is.null(x)) return(code)
+    if (!is.null(code)) return(code)
   }
   .cstr_apply(args, "ggplot2::theme", ...)
 }

--- a/R/s3-ggplot2-theme.R
+++ b/R/s3-ggplot2-theme.R
@@ -40,6 +40,7 @@ strip_theme <- function(x) {
   x$strip.text$margin <- NULL
   x$strip.switch.pad.grid <- NULL
   x$strip.switch.pad.wrap <- NULL
+  x$legend.key.spacing <- NULL
   x
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -301,8 +301,8 @@ split_by_line <- function(x) {
 
 # evaluate default values in the function's namespace
 # fun, pkg: strings
-defaults_arg_values <- function(fun, pkg) {
-  args_lng <- head(as.list(getFromNamespace(fun, pkg)), -1)
+defaults_arg_values <- function(fun_val, pkg) {
+  args_lng <- head(as.list(fun_val), -1)
   defaults_lng <- Filter(function(x) !identical(x, quote(expr=)), args_lng)
   lapply(defaults_lng, eval, asNamespace(pkg))
 }


### PR DESCRIPTION
For #265 

This solves the failure mentioned in the ticket and some more. But the snapshot will be different when the new version will be released.

@krlmlr how can we deal with that ? do we wait for the upcoming ggplot2 CRAN version to break constructive and release a new version soon after ? Do we release first a version that skips ggplot tests for ggplot >= 3.5 ? to then switch them back on on our next version ?