### PR TITLE
feat: add a `justify` argument to `opts_tbl_df()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # constructive (development version)
 
+* `opts_tbl_df()` gains a `justify` argument to control the justification of
+  columns with `constructor = `"tribble"`.
 * `construct()` and `construct_multi()` gain the arguments `unicode_representation` 
   and `escape` previously used by `opts_atomic()` and these are now not only 
   applied on strings but also on element names and variable names.

--- a/R/s3-tbl_df.R
+++ b/R/s3-tbl_df.R
@@ -16,16 +16,20 @@ constructors$tbl_df <- new.env()
 #' @inheritParams opts_atomic
 #' @param trailing_comma Boolean, whether to leave a trailing comma at the end of the constructor call
 #' calls
+#' @param justify Character. Justification for columns if `constructor` is `"tribble"`
 #'
 #' @return An object of class <constructive_options/constructive_options_tbl_df>
 #' @export
-opts_tbl_df <- function(constructor = c("tibble", "tribble", "next", "list"), ..., trailing_comma = TRUE) {
+opts_tbl_df <- function(constructor = c("tibble", "tribble", "next", "list"),
+                        ...,
+                        trailing_comma = TRUE,
+                        justify = c("left", "right", "centre", "none")) {
   .cstr_combine_errors(
     constructor <- .cstr_match_constructor(constructor, "tbl_df"),
-    check_dots_empty(),
-    abort_not_boolean(trailing_comma)
+    check_dots_empty(), abort_not_boolean(trailing_comma)
   )
-  .cstr_options("tbl_df", constructor = constructor, trailing_comma = trailing_comma)
+  justify <- match.arg(justify)
+  .cstr_options("tbl_df", constructor = constructor, trailing_comma = trailing_comma, justify = justify)
 }
 
 #' @export
@@ -33,7 +37,7 @@ opts_tbl_df <- function(constructor = c("tibble", "tribble", "next", "list"), ..
   opts <- .cstr_fetch_opts("tbl_df", ...)
   if (is_corrupted_tbl_df(x) || opts$constructor == "next") return(NextMethod())
   constructor <- constructors$tbl_df[[opts$constructor]]
-  constructor(x, ..., trailing_comma = opts$trailing_comma)
+  constructor(x, ..., trailing_comma = opts$trailing_comma, justify = opts$justify)
 }
 
 is_corrupted_tbl_df <- function(x) {
@@ -53,7 +57,7 @@ constructors$tbl_df$tibble <- function(x, ..., trailing_comma = TRUE) {
   repair_attributes_tbl_df(x, code, ...)
 }
 
-constructors$tbl_df$tribble <- function(x, ..., trailing_comma = TRUE) {
+constructors$tbl_df$tribble <- function(x, ..., trailing_comma = TRUE, justify = "left") {
   # fall back to tibble if no row or has df cols or list cols containing only length 1 elements
   if (!nrow(x)) return(constructors$tbl_df$tibble(x, ...))
   is_unsupported_col <- function(col) {
@@ -66,7 +70,7 @@ constructors$tbl_df$tribble <- function(x, ..., trailing_comma = TRUE) {
   code_df <- x
   code_df[] <- lapply(x, function(col) paste0(sapply(col, function(cell) paste(.cstr_construct(cell, ...), collapse = "")), ","))
   code_df <- rbind(paste0("~", sapply(names(x), protect), ","), as.data.frame(code_df))
-  code_df[] <- lapply(code_df, format)
+  code_df[] <- lapply(code_df, format, justify = justify)
   code <- do.call(paste, code_df)
   if (!trailing_comma) {
     code[[length(code)]] <- sub(", *$", "", code[[length(code)]])

--- a/man/construct.Rd
+++ b/man/construct.Rd
@@ -179,7 +179,7 @@ We can provide calls to `opts_*()` functions to the `...` argument. Each of thes
   \item \code{\link[=opts_simpleMessage]{opts_simpleMessage}(constructor = c("simpleMessage", "next"), ...)}
   \item \code{\link[=opts_simpleUnit]{opts_simpleUnit}(constructor = c("unit", "next", "atomic"), ...)}
   \item \code{\link[=opts_simpleWarning]{opts_simpleWarning}(constructor = c("simpleWarning", "next"), ...)}
-  \item \code{\link[=opts_tbl_df]{opts_tbl_df}(constructor = c("tibble", "tribble", "next", "list"), ..., trailing_comma = TRUE)}
+  \item \code{\link[=opts_tbl_df]{opts_tbl_df}(constructor = c("tibble", "tribble", "next", "list"), ..., trailing_comma = TRUE, justify = c("left", "right", "centre", "none"))}
   \item \code{\link[=opts_theme]{opts_theme}(constructor = c("theme", "next", "list"), ...)}
   \item \code{\link[=opts_ts]{opts_ts}(constructor = c("ts", "next", "atomic"), ...)}
   \item \code{\link[=opts_uneval]{opts_uneval}(constructor = c("aes", "next", "list"), ...)}

--- a/man/opts_tbl_df.Rd
+++ b/man/opts_tbl_df.Rd
@@ -7,7 +7,8 @@
 opts_tbl_df(
   constructor = c("tibble", "tribble", "next", "list"),
   ...,
-  trailing_comma = TRUE
+  trailing_comma = TRUE,
+  justify = c("left", "right", "centre", "none")
 )
 }
 \arguments{
@@ -17,6 +18,8 @@ opts_tbl_df(
 
 \item{trailing_comma}{Boolean, whether to leave a trailing comma at the end of the constructor call
 calls}
+
+\item{justify}{Character. Justification for columns if \code{constructor} is \code{"tribble"}}
 }
 \value{
 An object of class <constructive_options/constructive_options_tbl_df>

--- a/tests/testthat/_snaps/s3-tbl_df.md
+++ b/tests/testthat/_snaps/s3-tbl_df.md
@@ -24,6 +24,15 @@
         "Paul", "Beatles",
       )
     Code
+      construct(dplyr::band_members, opts_tbl_df(constructor = "tribble", justify = "right"))
+    Output
+      tibble::tribble(
+         ~name,     ~band,
+        "Mick",  "Stones",
+        "John", "Beatles",
+        "Paul", "Beatles",
+      )
+    Code
       construct(dplyr::group_by(dplyr::band_members, band))
     Output
       tibble::tibble(name = c("Mick", "John", "Paul"), band = c("Stones", "Beatles", "Beatles")) |>

--- a/tests/testthat/test-s3-tbl_df.R
+++ b/tests/testthat/test-s3-tbl_df.R
@@ -6,6 +6,7 @@ test_that("tbl_df", {
     construct(dplyr::band_members, opts_tbl_df("next"))
     construct(dplyr::band_members, opts_tbl_df("next"), opts_data.frame("next"))
     construct(dplyr::band_members, opts_tbl_df(constructor = "tribble"))
+    construct(dplyr::band_members, opts_tbl_df(constructor = "tribble", justify = "right"))
     construct(dplyr::group_by(dplyr::band_members, band))
   })
 })


### PR DESCRIPTION
Very small new feature. In `tribble()` calls I usually right-justify so the commas all line up - this is now possible like so:

``` r
devtools::load_all()
#> ℹ Loading constructive

# Default behaviour unchanged:
construct(
  dplyr::band_instruments,
  opts_tbl_df(constructor = "tribble")
)
#> tibble::tribble(
#>   ~name,   ~plays,
#>   "John",  "guitar",
#>   "Paul",  "bass",
#>   "Keith", "guitar",
#> )

# New additional control over justification:
construct(
  dplyr::band_instruments,
  opts_tbl_df(constructor = "tribble", justify = "right")
)
#> tibble::tribble(
#>     ~name,   ~plays,
#>    "John", "guitar",
#>    "Paul",   "bass",
#>   "Keith", "guitar",
#> )
```

<sup>Created on 2024-05-24 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

* Also adds support for `justification = "none"` and `justification = "centre"`
* Also adds a new snapshot test checking right-justification works as expected
* Also adds a bullet to `NEWS.md`