### PR TITLE
bypass S3 methods

### DIFF
--- a/R/bypass.R
+++ b/R/bypass.R
@@ -1,0 +1,86 @@
+# This script defines shims of base R functions that don't trigger S3 dispatch.
+# Indeed in this package S3 dispatch is more likely to be accidental than desired.
+# When dispatch is actually desired, we should use the `base::fun` form.
+# Ultimately we should use the {bypass} package, more specifically `global_bypass()`
+
+# vectors ======================================================================
+
+c <- function(...) base::c(NULL, ...)
+
+unlist <- function(x, recursive = TRUE, use.names = TRUE) {
+  base::unlist(unclass(x))
+}
+
+lapply <- function(X, FUN, ...) {
+  base::lapply(unclass(X), FUN, ...)
+}
+
+sapply <- function(X, FUN, ..., simplify = TRUE, USE.NAMES = TRUE) {
+  base::sapply(unclass(X), FUN, ..., simplify = simplify, USE.NAMES = USE.NAMES)
+}
+
+# dimensions ===================================================================
+
+length <- function(x) {
+  if (is.environment(x)) return(base::length(ls(x, all.names = TRUE)))
+  base::length(unclass(x))
+}
+
+lengths <- function(x, use.names = TRUE) {
+  sapply(x, length, USE.NAMES = use.names)
+}
+
+dim <- function(x) {
+  attr(x, "dim")
+}
+
+`dim<-` <- function(x, value) {
+  attr(x, "dim") <- value
+  x
+}
+
+names <- function(x) {
+  if (is.environment(x)) return(ls(x, all.names = TRUE, sorted = FALSE))
+  base::names(unclass(x))
+}
+
+`names<-` <- function(x, value) {
+  attr(x, "names") <- value
+  x
+}
+
+# subset =======================================================================
+
+`$` <- function(e1, e2) {
+  .subset2(e1, as.character(substitute(e2)))
+}
+
+`[` <- function(x, ...) {
+  cl <- oldClass(x)
+  x <- unclass(x)
+  out <- base::`[`(x, ...)
+  oldClass(out) <- cl
+  out
+}
+
+`[<-` <- function(x, ..., value) {
+  cl <- oldClass(x)
+  x <- unclass(x)
+  x <- base::`[<-`(x, ..., value = value)
+  oldClass(x) <- cl
+  x
+}
+
+`[[<-` <- function(x, ..., value) {
+  cl <- oldClass(x)
+  x <- unclass(x)
+  x <- base::`[[<-`(x, ..., value = value)
+  oldClass(x) <- cl
+  x
+}
+
+`$<-` <- function(e1, e2, value) {
+  e1[[as.character(substitute(e2))]] <- value
+  e1
+}
+

--- a/R/s3-dots.R
+++ b/R/s3-dots.R
@@ -9,7 +9,7 @@ constructors$dots <- new.env()
 #'
 #'
 #' Depending on `constructor`, we construct the object as follows:
-#' * `"default"` : We use the construct `(function(...) environment()$...)(a = x, y)`
+#' * `"default"` : We use the construct `(function(...) get(\"...\"))(a = x, y)`
 #'   which we evaluate in the correct environment.
 #'
 #' @param constructor String. Name of the function used to construct the object.
@@ -44,7 +44,7 @@ constructors$dots$default <- function(x, ...) {
   if (length(unique_env) == 1) {
     unique_env <- unique_env[[1]]
     exprs <- lapply(quo_dots, rlang::quo_get_expr)
-    code_lng <- rlang::expr((function(...) environment()$...)(!!!exprs))
+    code_lng <- rlang::expr((function(...) get("..."))(!!!exprs))
     code <- deparse_call0(code_lng, ...)
     env_code <- .cstr_construct(unique_env, ...)
     code <- .cstr_apply(list(code, envir = env_code), "evalq", recurse = FALSE)
@@ -53,7 +53,7 @@ constructors$dots$default <- function(x, ...) {
   # strip class since it's not necessary for splicing
   quo_code <- .cstr_construct(unclass(quo_dots), ...)
   quo_code[[1]] <- paste0("!!!", quo_code[[1]])
-  code <- .cstr_wrap(quo_code, "(function(...) environment()$...)")
+  code <- .cstr_wrap(quo_code, "(function(...) get(\"...\"))")
   code <- .cstr_wrap(code, "rlang::inject")
 
   repair_attributes_dots(x, code, ...)

--- a/R/utils.R
+++ b/R/utils.R
@@ -178,10 +178,11 @@ scrub_ggplot <- function(x) {
 
 # Thanks to Zi Lin : https://stackoverflow.com/questions/75960769
 flatten.scales <- function(gg) {
+  `$` <- base::`$`
   # take stock how many different scales are contained within the top-level
   # scale list, & sort their names alphabetically for consistency
-  orig.scales <- gg[["scales"]]
-  scale.count <- orig.scales$n()
+  orig.scales <-gg[["scales"]]
+  scale.count <-  orig.scales$n()
   scale.aesthetics <- lapply(seq_len(scale.count),
                              function(i) orig.scales$scales[[i]]$aesthetics)
   names(scale.aesthetics) <- lapply(scale.aesthetics,

--- a/man/opts_dots.Rd
+++ b/man/opts_dots.Rd
@@ -22,7 +22,7 @@ is provided in case users want to extend the method with other constructors.
 \details{
 Depending on \code{constructor}, we construct the object as follows:
 \itemize{
-\item \code{"default"} : We use the construct \code{(function(...) environment()$...)(a = x, y)}
+\item \code{"default"} : We use the construct \verb{(function(...) get(\\"...\\"))(a = x, y)}
 which we evaluate in the correct environment.
 }
 }

--- a/tests/testthat/_snaps/s3-dots.md
+++ b/tests/testthat/_snaps/s3-dots.md
@@ -1,18 +1,18 @@
 # dots
 
     Code
-      dots1 <- local((function(...) environment()$...)(a = x, y))
+      dots1 <- local((function(...) get("..."))(a = x, y))
       construct(dots1, opts_environment("list2env"))
     Output
       evalq(
-        (function(...) environment()$...)(a = x, y),
+        (function(...) get("..."))(a = x, y),
         envir = new.env(parent = asNamespace("constructive"))
       )
     Code
       construct(structure(dots1, class = "foo"), opts_environment("list2env"))
     Output
       evalq(
-        (function(...) environment()$...)(a = x, y),
+        (function(...) get("..."))(a = x, y),
         envir = new.env(parent = asNamespace("constructive"))
       ) |>
         structure(class = "foo")
@@ -21,18 +21,18 @@
         y <- 1
         g(y = y, ...)
       })
-      g <- (function(...) environment()$...)
+      g <- (function(...) get("..."))
       x <- 1
       dots2 <- local(f(x = x))
       construct(dots2, opts_environment("list2env"))
     Output
-      rlang::inject((function(...) environment()$...)(!!!list(
+      rlang::inject((function(...) get("..."))(!!!list(
         y = rlang::new_quosure(
           quote(y),
           list2env(
             list(
               ... = evalq(
-                (function(...) environment()$...)(x = x),
+                (function(...) get("..."))(x = x),
                 envir = new.env(parent = asNamespace("constructive"))
               ),
               y = 1

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -10,3 +10,7 @@ colon_colon <- `::`
     }
   )
 }
+
+# we want regular behavior of internal generics in the tests
+`[` <- base::`[`
+`$` <- base::`$`

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -14,3 +14,4 @@ colon_colon <- `::`
 # we want regular behavior of internal generics in the tests
 `[` <- base::`[`
 `$` <- base::`$`
+length <- base::length

--- a/tests/testthat/test-s3-dots.R
+++ b/tests/testthat/test-s3-dots.R
@@ -2,7 +2,7 @@ test_that("dots", {
   expect_pipe_snapshot({
     # if dots1 and the evaluation env of `...` is in the same env we have
     # infinite recursion issues so we use `local()`
-    dots1 <- local((function(...) environment()$...)(a=x, y))
+    dots1 <- local((function(...) get("..."))(a=x, y))
     construct(dots1, opts_environment("list2env"))
     construct(structure(dots1, class = "foo"), opts_environment("list2env"))
 
@@ -10,7 +10,7 @@ test_that("dots", {
       y <- 1
       g(y = y, ...)
     }
-    g <- function(...) environment()$...
+    g <- function(...) get("...")
     x <- 1
     dots2 <- local(f(x = x))
     construct(dots2, opts_environment("list2env"))


### PR DESCRIPTION
constructive was brittle if an object had a subclass not supported by constructive but with a `$` or `[[` method (or similar), now we override some internal generics, we should use the bypass package ultimately