### PR TITLE
improve data.frame, tibble, data.table

### DIFF
--- a/R/s3-data.table.R
+++ b/R/s3-data.table.R
@@ -45,6 +45,11 @@ constructors$data.table$list <- function(x, ...) {
 }
 
 constructors$data.table$data.table <- function(x, selfref, ...) {
+  # Fall back on list constructor if relevant
+  arg_names <- c("keep.rownames", "check.names", "key", "stringsAsFactors")
+  df_has_problematic_names <- any(names(x) %in% arg_names)
+  if (df_has_problematic_names) return(.cstr_construct.list(x, ...))
+
   key <- attr(x, "sorted")
   if (!is.null(key)) {
     args <- c(x, key = key)

--- a/R/s3-tbl_df.R
+++ b/R/s3-tbl_df.R
@@ -48,7 +48,7 @@ opts_tbl_df <- function(constructor = c("tibble", "tribble", "next", "list"),
 
 is_corrupted_tbl_df <- function(x) {
   # FIXME: ?rownames says a tibble can have rownames but as_tibble(mtcars) removes them
-  is_corrupted_data.frame(x)
+  is_corrupted_data.frame(x) || !identical(attr(x, "row.names"), seq_len(nrow(x)))
 }
 
 constructors$tbl_df$list <- function(x, ..., trailing_comma = TRUE) {
@@ -56,6 +56,9 @@ constructors$tbl_df$list <- function(x, ..., trailing_comma = TRUE) {
 }
 
 constructors$tbl_df$tibble <- function(x, ..., trailing_comma = TRUE) {
+  arg_names <- c(".rows", ".name_repair ")
+  df_has_problematic_names <- any(names(x) %in% arg_names)
+  if (df_has_problematic_names) return(.cstr_construct.list(x, ...))
   # construct idiomatic code
   code <- .cstr_apply(x, fun = "tibble::tibble", ..., trailing_comma = trailing_comma)
 

--- a/tests/testthat/_snaps/s3-data.frame.md
+++ b/tests/testthat/_snaps/s3-data.frame.md
@@ -120,4 +120,13 @@
                 a
       'two words'
       ")
+    Code
+      constructive::construct(as.data.frame(list(row.names = 1:2)))
+    Output
+      list(row.names = 1:2) |>
+        structure(class = "data.frame", row.names = c(NA, -2L))
+    Code
+      construct(data.frame(row.names = c("a", "b")))
+    Output
+      data.frame(row.names = c("a", "b"))
 

--- a/tests/testthat/test-s3-data.frame.R
+++ b/tests/testthat/test-s3-data.frame.R
@@ -45,6 +45,9 @@ test_that("data.frame", {
       class = "data.frame"
     ))
     construct(data.frame(a = "two words"), constructive::opts_data.frame("read.table"))
+    # column named with a problematic name
+    constructive::construct(as.data.frame(list(row.names = 1:2)))
+    construct(data.frame(row.names = c("a", "b")))
   })
 })
 


### PR DESCRIPTION
So we fall back to list when the df contains columns named as the constructor's arguments (like "row.names" etc)