### PR TITLE
override expect snapshot

### DIFF
--- a/R/expect.R
+++ b/R/expect.R
@@ -1,8 +1,0 @@
-expect_snapshot <- function(code) {
-  transform <- function(out) {
-    out <- gsub("%>%", "|>", out, fixed = TRUE)
-    out <- gsub("= [.]([,)])", "= _\\1", out)
-    out
-  }
-  rlang::inject(testthat::expect_snapshot({{ code }}, transform = transform))
-}

--- a/R/expect.R
+++ b/R/expect.R
@@ -1,4 +1,4 @@
-expect_pipe_snapshot <- function(code) {
+expect_snapshot <- function(code) {
   transform <- function(out) {
     out <- gsub("%>%", "|>", out, fixed = TRUE)
     out <- gsub("= [.]([,)])", "= _\\1", out)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -28,3 +28,5 @@ expect_snapshot <- function(code) {
     )
   ))
 }
+# have a copy in the global env for some examples in CI
+.GlobalEnv$expect_snapshot <- expect_snapshot

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -17,10 +17,14 @@ colon_colon <- `::`
 length <- base::length
 
 expect_snapshot <- function(code) {
-  transform <- function(out) {
-    out <- gsub("%>%", "|>", out, fixed = TRUE)
-    out <- gsub("= [.]([,)])", "= _\\1", out)
-    out
-  }
-  rlang::inject(testthat::expect_snapshot({{ code }}, transform = transform))
+  eval.parent(substitute(
+    testthat::expect_snapshot(
+      code,
+      transform = function(out) {
+        out <- gsub("%>%", "|>", out, fixed = TRUE)
+        out <- gsub("= [.]([,)])", "= _\\1", out)
+        out
+      }
+    )
+  ))
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -15,3 +15,12 @@ colon_colon <- `::`
 `[` <- base::`[`
 `$` <- base::`$`
 length <- base::length
+
+expect_snapshot <- function(code) {
+  transform <- function(out) {
+    out <- gsub("%>%", "|>", out, fixed = TRUE)
+    out <- gsub("= [.]([,)])", "= _\\1", out)
+    out
+  }
+  rlang::inject(testthat::expect_snapshot({{ code }}, transform = transform))
+}

--- a/tests/testthat/test-abort.R
+++ b/tests/testthat/test-abort.R
@@ -1,5 +1,5 @@
 test_that("abort", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     foo <- function(x = c("a", "b"), y, z, ...) {
       .cstr_combine_errors(
         x <- rlang::arg_match(x),
@@ -24,7 +24,7 @@ test_that("abort", {
 })
 
 test_that("describe", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     writeLines(describe(letters))
     writeLines(describe(mean))
   })

--- a/tests/testthat/test-contains_self_reference.R
+++ b/tests/testthat/test-contains_self_reference.R
@@ -41,21 +41,21 @@ test_that("self reference fails properly", {
   expect_error(construct(env, opts_environment("list2env")), "self-references")
   expect_error(construct(env, opts_environment("new_environment")), "self-references")
   expect_error(construct(env, opts_environment("as.environment")), "self-references")
-  expect_pipe_snapshot(construct(env, opts_environment(predefine = TRUE)))
+  expect_snapshot(construct(env, opts_environment(predefine = TRUE)))
 
   env <- new.env(parent = baseenv())
   env$x <- structure(1, foo = env)
   expect_error(construct(env, opts_environment("list2env")), "self-references")
   expect_error(construct(env, opts_environment("new_environment")), "self-references")
   expect_error(construct(env, opts_environment("as.environment")), "self-references")
-  expect_pipe_snapshot(construct(env, opts_environment(predefine = TRUE)))
+  expect_snapshot(construct(env, opts_environment(predefine = TRUE)))
 
   env <- new.env(parent = baseenv())
   attr(env, "foo") <- env
   expect_error(construct(env, opts_environment("list2env")), "self-references")
   expect_error(construct(env, opts_environment("new_environment")), "self-references")
   expect_error(construct(env, opts_environment("as.environment")), "self-references")
-  expect_pipe_snapshot(construct(env, opts_environment(predefine = TRUE)))
+  expect_snapshot(construct(env, opts_environment(predefine = TRUE)))
 
   env <- new.env(parent = baseenv())
   env$f <- function() NULL
@@ -78,7 +78,7 @@ test_that("self reference fails properly", {
     opts_environment("as.environment"),
     opts_function(environment = FALSE),
     check = FALSE))
-  expect_pipe_snapshot(construct(env, opts_environment(predefine = TRUE)))
+  expect_snapshot(construct(env, opts_environment(predefine = TRUE)))
 
   parent <- new.env(parent = baseenv())
   env <- new.env(parent = parent)
@@ -89,5 +89,5 @@ test_that("self reference fails properly", {
   expect_error(construct(env, opts_environment("list2env", recurse = TRUE)), "self-references")
   expect_error(construct(env, opts_environment("new_environment", recurse = TRUE)), "self-references")
   # FIXME: this doesn't work yet but it's quite contrived!
-  # expect_pipe_snapshot(construct(env, opts_environment(predefine = TRUE)))
+  # expect_snapshot(construct(env, opts_environment(predefine = TRUE)))
 })

--- a/tests/testthat/test-deparse_call.R
+++ b/tests/testthat/test-deparse_call.R
@@ -1,5 +1,5 @@
 test_that("deparse_call()", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     deparse_call(call("::", 1, 2), style = FALSE)
     deparse_call(call("::", "a", quote(b)), style = FALSE)
     deparse_call(call("::", quote(a), "b"), style = FALSE)
@@ -121,7 +121,7 @@ test_that("deparse_call()", {
 test_that("deparse_call() for R >= 4.1", {
   # Due to bypass.R
   skip_if(base::`<`(getRversion(), "4.1"))
-  expect_pipe_snapshot({
+  expect_snapshot({
     deparse_call(quote(`🐶`), style = FALSE)
     deparse_call(quote(`🐶`), unicode_representation = "unicode")
   })

--- a/tests/testthat/test-others.R
+++ b/tests/testthat/test-others.R
@@ -24,7 +24,7 @@ test_that("noquote is supported", {
 })
 
 test_that("compare_options", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(evalq(x ~ y, asNamespace("stats")))
     construct(evalq(x ~ y, asNamespace("stats")), opts_formula(environment = FALSE))
     construct(evalq(x ~ y, asNamespace("stats")), opts_formula(environment = FALSE), compare = compare_options(ignore_formula_env = TRUE))

--- a/tests/testthat/test-repair_attributes.R
+++ b/tests/testthat/test-repair_attributes.R
@@ -1,5 +1,5 @@
 test_that("structure corner cases", {
   a <- 1
   attributes(a) <- list(.Names = "name1", names = "name2", .Label = "label1", levels = "label2")
-  expect_pipe_snapshot(construct(a))
+  expect_snapshot(construct(a))
 })

--- a/tests/testthat/test-s3-AsIs.R
+++ b/tests/testthat/test-s3-AsIs.R
@@ -1,5 +1,5 @@
 test_that("AsIs", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(I(month.abb))
     construct(I(month.abb), opts_AsIs("next"))
     construct(I(head(cars,2)))

--- a/tests/testthat/test-s3-Date.R
+++ b/tests/testthat/test-s3-Date.R
@@ -12,7 +12,7 @@ test_that("Date", {
     tz = "GMT"
   )
 
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(structure(19469, class = "Date"))
     construct(structure(19469, class = "Date"), opts_Date("next"))
     construct(structure(19469, class = "Date"), opts_Date("double"))

--- a/tests/testthat/test-s3-POSIXct.R
+++ b/tests/testthat/test-s3-POSIXct.R
@@ -16,7 +16,7 @@ test_that("POSIXct", {
   withr::local_timezone("UTC")
   sys_time_1970 <- Sys.time()
   sys_time_1970[[1]] <- 0
-  expect_pipe_snapshot({
+  expect_snapshot({
     # ordered
     construct(.leap.seconds[1:4])
     construct(sys_time_1970)

--- a/tests/testthat/test-s3-POSIXlt.R
+++ b/tests/testthat/test-s3-POSIXlt.R
@@ -15,7 +15,7 @@ test_that("POSIXlt-all-versions", {
   withr::local_timezone("UTC")
   sys_time_1970 <- Sys.time()
   sys_time_1970[[1]] <- 0
-  expect_pipe_snapshot({
+  expect_snapshot({
     # ordered
     construct(as.POSIXlt(.leap.seconds[1:4]))
     construct(as.POSIXlt(.leap.seconds[1:4]))
@@ -44,7 +44,7 @@ test_that("POSIXlt-from-4.3", {
   withr::local_timezone("UTC")
   sys_time_1970 <- Sys.time()
   sys_time_1970[[1]] <- 0
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(as.POSIXlt(.leap.seconds[1:4]), opts_POSIXlt("next"))
     construct(as.POSIXlt(.leap.seconds[1:4]), opts_POSIXlt("list"))
   })
@@ -70,7 +70,7 @@ test_that("POSIXlt-pre-4.3", {
   withr::local_timezone("UTC")
   sys_time_1970 <- Sys.time()
   sys_time_1970[[1]] <- 0
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(as.POSIXlt(.leap.seconds[1:4]), opts_POSIXlt("next"))
     construct(as.POSIXlt(.leap.seconds[1:4]), opts_POSIXlt("list"))
   })

--- a/tests/testthat/test-s3-array.R
+++ b/tests/testthat/test-s3-array.R
@@ -1,5 +1,5 @@
 test_that("array", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(as.array(month.abb))
     construct(as.array(month.abb), opts_array("next"))
     construct(array(1:3, c(2,4)))

--- a/tests/testthat/test-s3-atomic.R
+++ b/tests/testthat/test-s3-atomic.R
@@ -181,7 +181,7 @@ test_that("attributes are repaired on length 0 atomics", {
 })
 
 test_that("atomic elements named `recursive` or `use.names`", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(structure(logical(1), names = "recursive"))
     construct(structure(integer(1), names = "recursive"))
     construct(structure(numeric(1), names = "recursive"))

--- a/tests/testthat/test-s3-atomic.R
+++ b/tests/testthat/test-s3-atomic.R
@@ -1,5 +1,5 @@
 test_that("numeric", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     # by default no scientific notation
     construct(10000)
     # by default scientific notation
@@ -39,7 +39,7 @@ test_that("numeric", {
 })
 
 test_that("other atomic", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(letters)
     construct(letters, one_liner = TRUE)
     construct(letters, opts_atomic(trim = 1, fill = "rlang"))
@@ -51,7 +51,7 @@ test_that("other atomic", {
 
 
 test_that("simplify atomic", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(c("a", "a", "b", "c", "c", "c", "c"))
     construct(c(foo = "a", "a", "b", "c", "c", "c", "c"))
     construct(c("a", "b", "a", "b","a", "b","a", "b"))
@@ -67,7 +67,7 @@ test_that("simplify atomic", {
 
 test_that("character", {
   # check = FALSE for raw strings to pass tests on older R versions
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct("'hello'")
     construct('"hello"')
     construct("'\"hello\"'", check = FALSE)
@@ -85,7 +85,7 @@ test_that("character", {
 })
 
 test_that("negative zeroes", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(-0)
     construct(c(-0, -0, -0))
     construct(c(0, -0, -0))
@@ -95,7 +95,7 @@ test_that("negative zeroes", {
 })
 
 test_that("complex", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(NA_complex_)
     construct(c(NA_complex_, NA_complex_))
     construct(c(NA_complex_, NA_complex_, NA_complex_))
@@ -117,7 +117,7 @@ test_that("complex", {
 
 
 test_that("NA and empty names", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(structure(logical(2), names = c("", "")))
     construct(structure(logical(2), names = c("", NA)))
     construct(structure(logical(2), names = c(NA, NA)))
@@ -164,7 +164,7 @@ test_that("NA and empty names", {
 })
 
 test_that("attributes are repaired on length 0 atomics", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(structure(character(0), foo = 1))
     construct(structure(double(0), foo = 1))
     construct(structure(integer(0), foo = 1))

--- a/tests/testthat/test-s3-blob.R
+++ b/tests/testthat/test-s3-blob.R
@@ -1,5 +1,5 @@
 test_that("blob", {
-  expect_pipe_snapshot({
+  expect_snapshot({
   construct(blob::as_blob(c("hello", "world")))
   construct(blob::as_blob(c("hello", "world")), opts_blob("new_blob"))
   construct(blob::as_blob(c("hello", "world")), opts_blob("as_blob"))

--- a/tests/testthat/test-s3-constructive_options.R
+++ b/tests/testthat/test-s3-constructive_options.R
@@ -1,5 +1,5 @@
 test_that("constructive_options", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(opts_Date("as.Date"))
     construct(opts_Date("as.Date"), opts_constructive_options("next"))
     construct(opts_Date("new_date"))

--- a/tests/testthat/test-s3-data.frame.R
+++ b/tests/testthat/test-s3-data.frame.R
@@ -1,5 +1,5 @@
 test_that("data.frame", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     # one line, implicit row names
     construct(head(cars,2))
     # multiline, with row names

--- a/tests/testthat/test-s3-data.table.R
+++ b/tests/testthat/test-s3-data.table.R
@@ -1,5 +1,5 @@
 test_that("data.table", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     dt1 <- data.table::data.table(head(cars,2))
     construct(dt1)
     construct(dt1, opts_data.table(selfref = TRUE))

--- a/tests/testthat/test-s3-difftime.R
+++ b/tests/testthat/test-s3-difftime.R
@@ -1,5 +1,5 @@
 test_that("difftime", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(as.difftime(1, units = "secs"))
     construct(as.difftime(2, units = "mins"))
   })

--- a/tests/testthat/test-s3-dm.R
+++ b/tests/testthat/test-s3-dm.R
@@ -1,5 +1,5 @@
 test_that("dm", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     # simple dm
     construct(dm::dm(cars1 = head(cars,2), cars2 = tail(cars,2)), check = FALSE)
     # skip because unstable

--- a/tests/testthat/test-s3-dots.R
+++ b/tests/testthat/test-s3-dots.R
@@ -1,5 +1,5 @@
 test_that("dots", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     # if dots1 and the evaluation env of `...` is in the same env we have
     # infinite recursion issues so we use `local()`
     dots1 <- local((function(...) get("..."))(a=x, y))

--- a/tests/testthat/test-s3-environment.R
+++ b/tests/testthat/test-s3-environment.R
@@ -1,5 +1,5 @@
 test_that("environment", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     # handle special cases
     construct(globalenv())
     construct(baseenv())

--- a/tests/testthat/test-s3-expression.R
+++ b/tests/testthat/test-s3-expression.R
@@ -1,5 +1,5 @@
 test_that("expression vectors", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     x <- expression(a = 1, x + y)
     construct(x)
     x[[2]] <- structure(quote(x + y), foo = 1)

--- a/tests/testthat/test-s3-externalptr.R
+++ b/tests/testthat/test-s3-externalptr.R
@@ -1,5 +1,5 @@
 test_that("externalptr", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     dt <- data.table::data.table(a = 1)
     class(dt) <- "data.frame"
     construct(dt)

--- a/tests/testthat/test-s3-factor.R
+++ b/tests/testthat/test-s3-factor.R
@@ -1,5 +1,5 @@
 test_that("factor", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     # simple factor with implict levels
     construct(factor(month.abb))
     construct(factor(month.abb), opts_factor("next"))

--- a/tests/testthat/test-s3-formula.R
+++ b/tests/testthat/test-s3-formula.R
@@ -2,7 +2,7 @@ test_that("formula", {
   #testthat::skip("skipping formula tests")
   local(
     envir = .GlobalEnv,
-    constructive:::expect_snapshot({
+    expect_snapshot({
       fml1 <- formula(lhs ~ rhs, .GlobalEnv)
       construct(fml1) # by default no env for constructor = "~"
       construct(fml1, opts_formula(constructor = "formula"))

--- a/tests/testthat/test-s3-formula.R
+++ b/tests/testthat/test-s3-formula.R
@@ -2,7 +2,7 @@ test_that("formula", {
   #testthat::skip("skipping formula tests")
   local(
     envir = .GlobalEnv,
-    constructive:::expect_pipe_snapshot({
+    constructive:::expect_snapshot({
       fml1 <- formula(lhs ~ rhs, .GlobalEnv)
       construct(fml1) # by default no env for constructor = "~"
       construct(fml1, opts_formula(constructor = "formula"))

--- a/tests/testthat/test-s3-function.R
+++ b/tests/testthat/test-s3-function.R
@@ -1,5 +1,5 @@
 test_that("function", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     f1 <- as.function(alist(x=, x), .GlobalEnv)
     f2 <- as.function(alist(x=, {x}), .GlobalEnv)
 

--- a/tests/testthat/test-s3-ggplot2-ggplot.R
+++ b/tests/testthat/test-s3-ggplot2-ggplot.R
@@ -9,7 +9,7 @@ test_that("ggplot-all-versions", {
     expect_faithful_ggplot_construction(p1, opts_Layer("environment"))
     expect_faithful_ggplot_construction(p2, opts_Layer("environment"))
 
-    expect_pipe_snapshot({
+    expect_snapshot({
       construct(p1, data = list(mpg_99 = mpg_99))
     })
 })
@@ -23,7 +23,7 @@ test_that("ggplot-after-R4.1.3", {
   p1 <- base_99 + ggplot2::scale_x_continuous(limits = c(1, 7))
   p2 <- p1 + ggplot2::scale_y_continuous(limits = c(10, 45)) + ggplot2::facet_wrap(~manufacturer)
 
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(p2, data = list(mpg_99 = mpg_99))
   })
 })
@@ -35,7 +35,7 @@ test_that("ggplot-pre-incl-R4.1.3", {
   p1 <- base_99 + ggplot2::scale_x_continuous(limits = c(1, 7))
   p2 <- p1 + ggplot2::scale_y_continuous(limits = c(10, 45)) + ggplot2::facet_wrap(~manufacturer)
 
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(p2, data = list(mpg_99 = mpg_99))
   })
 })

--- a/tests/testthat/test-s3-grouped_df.R
+++ b/tests/testthat/test-s3-grouped_df.R
@@ -1,5 +1,5 @@
 test_that("grouped_df", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(dplyr::group_by(head(cars,2), dist))
   })
 })

--- a/tests/testthat/test-s3-language.R
+++ b/tests/testthat/test-s3-language.R
@@ -18,7 +18,7 @@ test_that("language after 4.1", {
 })
 
 test_that("complex language", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     x <- quote(a(1)(2))
     attr(x[[1]], "foo") <- "bar"
     construct(x)

--- a/tests/testthat/test-s3-list.R
+++ b/tests/testthat/test-s3-list.R
@@ -38,7 +38,7 @@ test_that("list", {
   `[.corrupted` <- function(...) stop()
   `[[.corrupted` <- function(...) stop()
   expect_error(length(corrupted_list))
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(corrupted_list)
   })
 })

--- a/tests/testthat/test-s3-matrix.R
+++ b/tests/testthat/test-s3-matrix.R
@@ -1,5 +1,5 @@
 test_that("matrix", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(WorldPhones)
     construct(matrix(1:9, 3))
     construct(matrix(1:9, 1))

--- a/tests/testthat/test-s3-mts.R
+++ b/tests/testthat/test-s3-mts.R
@@ -1,6 +1,6 @@
 test_that("mts", {
   skip_if(with_versions(R >= "4.3"))
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(ts(matrix(1:9, 3, 3), start = c(1961, 1), frequency = 12))
     construct(ts(matrix(1:9, 3, 3), start = c(1961, 1), frequency = 12), opts_mts("next"))
     construct(ts(matrix(1:9, 3, 3), start = c(1961, 1), frequency = 12), opts_mts("atomic"))

--- a/tests/testthat/test-s3-numeric_version.R
+++ b/tests/testthat/test-s3-numeric_version.R
@@ -1,5 +1,5 @@
 test_that("numeric_version(), package_version(), R_system_version()", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(numeric_version("1.2.3"))
     construct(numeric_version("1.2.3"), opts_numeric_version("next"))
     construct(numeric_version("1.2.3"), opts_numeric_version("list"))

--- a/tests/testthat/test-s3-ordered.R
+++ b/tests/testthat/test-s3-ordered.R
@@ -1,5 +1,5 @@
 test_that("ordered", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     # ordered
     construct(factor(month.abb, ordered = TRUE))
     construct(factor(month.abb, ordered = TRUE))

--- a/tests/testthat/test-s3-quosure.R
+++ b/tests/testthat/test-s3-quosure.R
@@ -1,5 +1,5 @@
 test_that("quosure", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(rlang::new_quosure(quote(x), .GlobalEnv))
     construct(rlang::new_quosure(quote(x), .GlobalEnv), opts_quosure("next"))
     construct(rlang::new_quosure(quote(x), .GlobalEnv), opts_quosure("language"))

--- a/tests/testthat/test-s3-quosures.R
+++ b/tests/testthat/test-s3-quosures.R
@@ -1,5 +1,5 @@
 test_that("quosures", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(
       rlang::new_quosures(list(
         rlang::new_quosure(quote(x)),

--- a/tests/testthat/test-s3-raw.R
+++ b/tests/testthat/test-s3-raw.R
@@ -1,6 +1,6 @@
 test_that("raw", {
   # check = FALSE for raw strings to pass tests on older R versions
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(raw(1))
     construct(raw(2))
     construct(raw(10))

--- a/tests/testthat/test-s3-rowwise_df.R
+++ b/tests/testthat/test-s3-rowwise_df.R
@@ -1,5 +1,5 @@
 test_that("rowwise_df", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(dplyr::rowwise(head(cars,2)))
     construct(dplyr::rowwise(head(cars,2), dist))
   })

--- a/tests/testthat/test-s3-tbl_df.R
+++ b/tests/testthat/test-s3-tbl_df.R
@@ -1,7 +1,7 @@
 test_that("tbl_df", {
   sys_time_1970 <- Sys.time()
   sys_time_1970[[1]] <- 0
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(dplyr::band_members)
     construct(dplyr::band_members, opts_tbl_df("next"))
     construct(dplyr::band_members, opts_tbl_df("next"), opts_data.frame("next"))

--- a/tests/testthat/test-s3-ts.R
+++ b/tests/testthat/test-s3-ts.R
@@ -1,5 +1,5 @@
 test_that("ts", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(ts(1:10, frequency = 4, start = c(1959, 2)))
     construct(ts(1:10, frequency = 4, start = c(1959, 2)), opts_ts("next"))
     construct(ts(1:10, frequency = 4, start = c(1959, 2)), opts_ts("atomic"))

--- a/tests/testthat/test-s3-vctrs_list_of.R
+++ b/tests/testthat/test-s3-vctrs_list_of.R
@@ -1,5 +1,5 @@
 test_that("vctrs_list_of", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     construct(vctrs::vec_c(vctrs::list_of(1, 2), vctrs::list_of(FALSE, TRUE)))
     construct(vctrs::vec_c(vctrs::list_of(1, 2), vctrs::list_of(FALSE, TRUE)), opts_vctrs_list_of("list"))
   })

--- a/tests/testthat/test-s4.R
+++ b/tests/testthat/test-s4.R
@@ -1,5 +1,5 @@
 test_that("s4", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     track <- setClass("track", slots = c(x="numeric", y="numeric"))
     construct(track)
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,5 +1,5 @@
 test_that("pipe works for one liners", {
-  expect_pipe_snapshot({
+  expect_snapshot({
     x <- 1
     attr(x, "foo") <- 2
     construct(x, one_liner = TRUE)


### PR DESCRIPTION
Closes #436

cc @krlmlr so you're not surprised later, we don't need to type expect_pipe_snapshot() anymore