### PR TITLE
classed matrices

### DIFF
--- a/R/construct_idiomatic.R
+++ b/R/construct_idiomatic.R
@@ -1,5 +1,7 @@
 #' @export
 .cstr_construct.default <- function(x, ...) {
+  if (is.matrix(x)) return(.cstr_construct.matrix(x, ...))
+  if (is.array(x)) return(.cstr_construct.array(x, ...))
   switch(
     typeof(x),
     environment = .cstr_construct.environment(x, ...),

--- a/tests/testthat/_snaps/s3-array.md
+++ b/tests/testthat/_snaps/s3-array.md
@@ -27,3 +27,11 @@
       array(1, dim = 1L) |>
         structure(class = "array")
 
+# classed array
+
+    Code
+      construct(structure(array(1:27, c(3, 3, 3)), class = "a"))
+    Output
+      array(1:27, dim = rep(3L, 3L)) |>
+        structure(class = "a")
+

--- a/tests/testthat/_snaps/s3-matrix.md
+++ b/tests/testthat/_snaps/s3-matrix.md
@@ -34,3 +34,11 @@
     Output
       array(1:9, dim = c(3L, 3L))
 
+# classed matrix
+
+    Code
+      construct(structure(matrix(1:9, 3), class = "a"))
+    Output
+      matrix(1:9, nrow = 3L, ncol = 3L) |>
+        structure(class = "a")
+

--- a/tests/testthat/_snaps/s3-mts.md
+++ b/tests/testthat/_snaps/s3-mts.md
@@ -1,4 +1,54 @@
-# mts
+# mts from 4.3
+
+    Code
+      construct(ts(matrix(1:9, 3, 3), start = c(1961, 1), frequency = 12))
+    Output
+      ts(
+        matrix(
+          1:9,
+          nrow = 3L,
+          ncol = 3L,
+          dimnames = list(NULL, c("Series 1", "Series 2", "Series 3"))
+        ),
+        frequency = 12,
+        start = 1961
+      )
+    Code
+      construct(ts(matrix(1:9, 3, 3), start = c(1961, 1), frequency = 12), opts_mts(
+        "next"))
+    Output
+      ts(
+        matrix(
+          1:9,
+          nrow = 3L,
+          ncol = 3L,
+          dimnames = list(NULL, c("Series 1", "Series 2", "Series 3"))
+        ) |>
+          structure(class = c("mts", "matrix", "array")),
+        frequency = 12,
+        start = 1961
+      ) |>
+        structure(
+          dim = c(3L, 3L),
+          dimnames = list(NULL, c("Series 1", "Series 2", "Series 3")),
+          class = c("mts", "ts", "matrix", "array")
+        )
+    Code
+      construct(ts(matrix(1:9, 3, 3), start = c(1961, 1), frequency = 12), opts_mts(
+        "atomic"))
+    Output
+      matrix(
+        1:9,
+        nrow = 3L,
+        ncol = 3L,
+        dimnames = list(NULL, c("Series 1", "Series 2", "Series 3"))
+      ) |>
+        structure(
+          tsp = c(1961, 1961.1666666666667, 12),
+          class = c("mts", "ts", "matrix", "array")
+        )
+
+# mts before 4.3
 
     Code
       construct(ts(matrix(1:9, 3, 3), start = c(1961, 1), frequency = 12))
@@ -37,10 +87,13 @@
       construct(ts(matrix(1:9, 3, 3), start = c(1961, 1), frequency = 12), opts_mts(
         "atomic"))
     Output
-      1:9 |>
+      matrix(
+        1:9,
+        nrow = 3L,
+        ncol = 3L,
+        dimnames = list(NULL, c("Series 1", "Series 2", "Series 3"))
+      ) |>
         structure(
-          dim = c(3L, 3L),
-          dimnames = list(NULL, c("Series 1", "Series 2", "Series 3")),
           tsp = c(1961, 1961.1666666666667, 12),
           class = c("mts", "ts", "matrix")
         )

--- a/tests/testthat/_snaps/s3-mts.md
+++ b/tests/testthat/_snaps/s3-mts.md
@@ -93,8 +93,5 @@
         ncol = 3L,
         dimnames = list(NULL, c("Series 1", "Series 2", "Series 3"))
       ) |>
-        structure(
-          tsp = c(1961, 1961.1666666666667, 12),
-          class = c("mts", "ts", "matrix")
-        )
+        structure(tsp = c(1961, 1961.1666666666667, 12), class = c("mts", "ts", "matrix"))
 

--- a/tests/testthat/test-s3-array.R
+++ b/tests/testthat/test-s3-array.R
@@ -7,3 +7,9 @@ test_that("array", {
     construct(structure(1, class = "array", dim = 1))
   })
 })
+
+test_that("classed array", {
+  expect_snapshot({
+    construct(structure(array(1:27, c(3,3,3)), class = "a"))
+  })
+})

--- a/tests/testthat/test-s3-matrix.R
+++ b/tests/testthat/test-s3-matrix.R
@@ -7,3 +7,9 @@ test_that("matrix", {
     construct(matrix(1:9, 3), opts_matrix("next"))
   })
 })
+
+test_that("classed matrix", {
+  expect_snapshot({
+    construct(structure(matrix(1:9, 3), class = "a"))
+  })
+})

--- a/tests/testthat/test-s3-mts.R
+++ b/tests/testthat/test-s3-mts.R
@@ -1,4 +1,13 @@
-test_that("mts", {
+test_that("mts from 4.3", {
+  skip_if(with_versions(R < "4.3"))
+  expect_snapshot({
+    construct(ts(matrix(1:9, 3, 3), start = c(1961, 1), frequency = 12))
+    construct(ts(matrix(1:9, 3, 3), start = c(1961, 1), frequency = 12), opts_mts("next"))
+    construct(ts(matrix(1:9, 3, 3), start = c(1961, 1), frequency = 12), opts_mts("atomic"))
+  })
+})
+
+test_that("mts before 4.3", {
   skip_if(with_versions(R >= "4.3"))
   expect_snapshot({
     construct(ts(matrix(1:9, 3, 3), start = c(1961, 1), frequency = 12))


### PR DESCRIPTION
they were constructed as a vector with a dim attribute, because the matrix method was only triggered when matrix was in the class.