### PR TITLE
recycling and duplicate names in dfs

### DIFF
--- a/.github/dep-suggests-matrix.json
+++ b/.github/dep-suggests-matrix.json
@@ -1,1 +1,0 @@
-{"package":["bit64","blob","clipr","data.table","DiagrammeR","DiagrammeRsvg","dm","dplyr","forcats","ggplot2","lubridate","pixarfilms","prettycode","reprex","roxygen2","rstudioapi","scales","sf","tidyselect","xts","zoo"]}

--- a/R/s3-data.frame.R
+++ b/R/s3-data.frame.R
@@ -13,11 +13,14 @@
 #' * `"list"` : Use `list()` and treat the class as a regular attribute.
 #'
 #' @param constructor String. Name of the function used to construct the object, see Details section.
+#' @param recycle Boolean. For the `"data.frame"` constructor. Whether to recycle
+#'   scalars to compress the output.
 #' @inheritParams opts_atomic
 #' @return An object of class <constructive_options/constructive_options_data.frame>
 #' @export
-opts_data.frame <- function(constructor = c("data.frame", "read.table", "next", "list"), ...) {
-  .cstr_options("data.frame", constructor = constructor[[1]], ...)
+opts_data.frame <- function(constructor = c("data.frame", "read.table", "next", "list"), ..., recycle = TRUE) {
+  abort_not_boolean(recycle)
+  .cstr_options("data.frame", constructor = constructor[[1]], ..., recycle = recycle)
 }
 
 #' @export
@@ -125,6 +128,7 @@ align_numerics <- function(x) {
 #' @export
 #' @method .cstr_construct.data.frame data.frame
 .cstr_construct.data.frame.data.frame <- function(x, ...) {
+  opts <- list(...)$opts$data.frame %||% opts_data.frame()
   # Fall back on list constructor if relevant
   df_has_list_cols <- any(sapply(x, function(col) is.list(col) && !inherits(col, "AsIs")))
   arg_names <- c("row.names", "check.rows", "check.names", "fix.empty.names", "stringsAsFactors")
@@ -132,6 +136,26 @@ align_numerics <- function(x) {
   if (df_has_list_cols || df_has_problematic_names) return(.cstr_construct.list(x, ...))
 
   args <- x
+
+  # recycle value for constant columns
+  if (opts$recycle && nrow(x) > 1 && ncol(x) > 1) {
+    # recycling depends on S3 subsetting so we can't be general here, but we might
+    # extend this list
+    # note : "POSIXlt" is coerced to "POSIXct" in data.frame so not relevant here
+    recyclable_classes <-
+      list(NULL, "factor", c("ordered", "factor"), "Date", c("POSIXct", "POSIXt"))
+    args <- lapply(args, function(x) {
+      if (
+        any(sapply(recyclable_classes, identical, oldClass(x))) &&
+        length(unique(x)) == 1 # &&
+        # !anyDuplicated(names(x)) # not necessary for data frames, but yes for tibble
+      ) {
+        return(base::`[`(x, 1))
+      }
+      x
+    })
+    if (all(lengths(args) == 1)) args[1] <- x[1]
+  }
 
   # include row.names arg only if necessary
   rn <- attr(x, "row.names")
@@ -142,7 +166,7 @@ align_numerics <- function(x) {
   if (!ncol(x) || !identical(rn, seq_len(nrow(x)))) args <- c(args, list(row.names = rn))
 
   # include check.names arg only if necessary
-  if (any(!is_syntactic(names(x)))) args <- c(args, list(check.names = FALSE))
+  if (any(!is_syntactic(names(x))) || anyDuplicated(names(x))) args <- c(args, list(check.names = FALSE))
 
   # build code recursively
   code <- .cstr_apply(args, fun = "data.frame", ...)

--- a/R/s3-data.table.R
+++ b/R/s3-data.table.R
@@ -12,12 +12,14 @@
 #' @param selfref Boolean. Whether to include the `.internal.selfref` attribute. It's
 #'   probably not useful, hence the default, `waldo::compare()` is used to assess the output
 #'   fidelity and doesn't check it, but if you really need to generate code that builds
-#'   an object `identical()` to the input you'll need to set this to `TRUE`.
+#'   an object `identical()` to the input you'll need to set this to `TRUE`.#'
+#' @param recycle Boolean. Whether to recycle scalars to compress the output.
 #' @inheritParams opts_atomic
 #' @return An object of class <constructive_options/constructive_options_data.table>
 #' @export
-opts_data.table <- function(constructor = c("data.table", "next", "list"), ..., selfref = FALSE) {
-  .cstr_options("data.table", constructor = constructor[[1]], ..., selfref = selfref)
+opts_data.table <- function(constructor = c("data.table", "next", "list"), ..., selfref = FALSE, recycle = TRUE) {
+  abort_not_boolean(recycle)
+  .cstr_options("data.table", constructor = constructor[[1]], ..., selfref = selfref, recycle = recycle)
 }
 
 #' @export
@@ -47,12 +49,32 @@ is_corrupted_data.table <- function(x) {
   df_has_problematic_names <- any(names(x) %in% arg_names)
   if (df_has_problematic_names) return(.cstr_construct.list(x, ...))
 
+  args <- x
+  # recycle value for constant columns
+  if (opts$recycle && nrow(x) > 1 && ncol(x) > 1) {
+    # recycling depends on S3 subsetting so we can't be general here, but we might
+    # extend this list
+    # note : "POSIXlt" is coerced to "POSIXct" in data.frame so not relevant here
+    recyclable_classes <-
+      list(NULL, "factor", c("ordered", "factor"), "Date", c("POSIXct", "POSIXt"))
+    args <- lapply(args, function(x) {
+      if (
+        any(sapply(recyclable_classes, identical, oldClass(x))) &&
+        length(unique(x)) == 1 # &&
+        # !anyDuplicated(names(x)) # not necessary for data frames, but yes for tibble
+      ) {
+        return(base::`[`(x, 1))
+      }
+      x
+    })
+    if (all(lengths(args) == 1)) args[1] <- x[1]
+  }
+
   key <- attr(x, "sorted")
   if (!is.null(key)) {
-    args <- c(x, key = key)
-  } else {
-    args <- x
+    args <- c(args, key = key)
   }
+
   code <- .cstr_apply(args, fun = "data.table::data.table", ...)
   repair_attributes_data.table(x, code, ..., selfref = opts$selfref)
 }

--- a/man/construct.Rd
+++ b/man/construct.Rd
@@ -197,9 +197,9 @@ We can provide calls to `opts_*()` functions to the `...` argument. Each of thes
   \item \code{\link[=opts_POSIXlt]{opts_POSIXlt}(constructor = c("as.POSIXlt", "next", "list"), ...)}
   \item \code{\link[=opts_quosure]{opts_quosure}(constructor = c("new_quosure", "next", "language"), ...)}
   \item \code{\link[=opts_quosures]{opts_quosures}(constructor = c("new_quosures", "next", "list"), ...)}
+  \item \code{\link[=opts_R_system_version]{opts_R_system_version}(constructor = c("R_system_version", "next", "list"), ...)}
   \item \code{\link[=opts_R6]{opts_R6}(constructor = c("R6Class", "next"), ...)}
   \item \code{\link[=opts_R6ClassGenerator]{opts_R6ClassGenerator}(constructor = c("R6Class", "next"), ...)}
-  \item \code{\link[=opts_R_system_version]{opts_R_system_version}(constructor = c("R_system_version", "next", "list"), ...)}
   \item \code{\link[=opts_raw]{opts_raw}(constructor = c("as.raw", "charToRaw"), ..., trim = NULL, fill = c("default", "rlang", "+", "...", "none"), compress = TRUE, representation = c("hexadecimal", "decimal"))}
   \item \code{\link[=opts_rel]{opts_rel}(constructor = c("rel", "next", "double"), ...)}
   \item \code{\link[=opts_rowwise_df]{opts_rowwise_df}(constructor = c("default", "next", "list"), ...)}

--- a/man/construct.Rd
+++ b/man/construct.Rd
@@ -150,8 +150,8 @@ We can provide calls to `opts_*()` functions to the `...` argument. Each of thes
   \item \code{\link[=opts_CoordQuickmap]{opts_CoordQuickmap}(constructor = c("coord_quickmap", "next", "environment"), ...)}
   \item \code{\link[=opts_CoordSf]{opts_CoordSf}(constructor = c("coord_sf", "next", "environment"), ...)}
   \item \code{\link[=opts_CoordTrans]{opts_CoordTrans}(constructor = c("coord_trans", "next", "environment"), ...)}
-  \item \code{\link[=opts_data.frame]{opts_data.frame}(constructor = c("data.frame", "read.table", "next", "list"), ...)}
-  \item \code{\link[=opts_data.table]{opts_data.table}(constructor = c("data.table", "next", "list"), ..., selfref = FALSE)}
+  \item \code{\link[=opts_data.frame]{opts_data.frame}(constructor = c("data.frame", "read.table", "next", "list"), ..., recycle = TRUE)}
+  \item \code{\link[=opts_data.table]{opts_data.table}(constructor = c("data.table", "next", "list"), ..., selfref = FALSE, recycle = TRUE)}
   \item \code{\link[=opts_Date]{opts_Date}(constructor = c("as.Date", "as_date", "date", "new_date", "as.Date.numeric", "as_date.numeric", "next", "double"), ..., origin = "1970-01-01")}
   \item \code{\link[=opts_difftime]{opts_difftime}(constructor = c("as.difftime", "next"), ...)}
   \item \code{\link[=opts_dm]{opts_dm}(constructor = c("dm", "next", "list"), ...)}
@@ -197,9 +197,9 @@ We can provide calls to `opts_*()` functions to the `...` argument. Each of thes
   \item \code{\link[=opts_POSIXlt]{opts_POSIXlt}(constructor = c("as.POSIXlt", "next", "list"), ...)}
   \item \code{\link[=opts_quosure]{opts_quosure}(constructor = c("new_quosure", "next", "language"), ...)}
   \item \code{\link[=opts_quosures]{opts_quosures}(constructor = c("new_quosures", "next", "list"), ...)}
-  \item \code{\link[=opts_R_system_version]{opts_R_system_version}(constructor = c("R_system_version", "next", "list"), ...)}
   \item \code{\link[=opts_R6]{opts_R6}(constructor = c("R6Class", "next"), ...)}
   \item \code{\link[=opts_R6ClassGenerator]{opts_R6ClassGenerator}(constructor = c("R6Class", "next"), ...)}
+  \item \code{\link[=opts_R_system_version]{opts_R_system_version}(constructor = c("R_system_version", "next", "list"), ...)}
   \item \code{\link[=opts_raw]{opts_raw}(constructor = c("as.raw", "charToRaw"), ..., trim = NULL, fill = c("default", "rlang", "+", "...", "none"), compress = TRUE, representation = c("hexadecimal", "decimal"))}
   \item \code{\link[=opts_rel]{opts_rel}(constructor = c("rel", "next", "double"), ...)}
   \item \code{\link[=opts_rowwise_df]{opts_rowwise_df}(constructor = c("default", "next", "list"), ...)}
@@ -211,7 +211,7 @@ We can provide calls to `opts_*()` functions to the `...` argument. Each of thes
   \item \code{\link[=opts_simpleMessage]{opts_simpleMessage}(constructor = c("simpleMessage", "next"), ...)}
   \item \code{\link[=opts_simpleUnit]{opts_simpleUnit}(constructor = c("unit", "next", "double"), ...)}
   \item \code{\link[=opts_simpleWarning]{opts_simpleWarning}(constructor = c("simpleWarning", "next"), ...)}
-  \item \code{\link[=opts_tbl_df]{opts_tbl_df}(constructor = c("tibble", "tribble", "next", "list"), ..., trailing_comma = TRUE, justify = c("left", "right", "centre", "none"))}
+  \item \code{\link[=opts_tbl_df]{opts_tbl_df}(constructor = c("tibble", "tribble", "next", "list"), ..., trailing_comma = TRUE, justify = c("left", "right", "centre", "none"), recycle = TRUE)}
   \item \code{\link[=opts_theme]{opts_theme}(constructor = c("theme", "next", "list"), ...)}
   \item \code{\link[=opts_ts]{opts_ts}(constructor = c("ts", "next", "atomic"), ...)}
   \item \code{\link[=opts_uneval]{opts_uneval}(constructor = c("aes", "next", "list"), ...)}

--- a/man/opts_data.frame.Rd
+++ b/man/opts_data.frame.Rd
@@ -6,13 +6,17 @@
 \usage{
 opts_data.frame(
   constructor = c("data.frame", "read.table", "next", "list"),
-  ...
+  ...,
+  recycle = TRUE
 )
 }
 \arguments{
 \item{constructor}{String. Name of the function used to construct the object, see Details section.}
 
 \item{...}{Additional options used by user defined constructors through the \code{opts} object}
+
+\item{recycle}{Boolean. For the \code{"data.frame"} constructor. Whether to recycle
+scalars to compress the output.}
 }
 \value{
 An object of class <constructive_options/constructive_options_data.frame>

--- a/man/opts_data.table.Rd
+++ b/man/opts_data.table.Rd
@@ -7,7 +7,8 @@
 opts_data.table(
   constructor = c("data.table", "next", "list"),
   ...,
-  selfref = FALSE
+  selfref = FALSE,
+  recycle = TRUE
 )
 }
 \arguments{
@@ -18,7 +19,9 @@ opts_data.table(
 \item{selfref}{Boolean. Whether to include the \code{.internal.selfref} attribute. It's
 probably not useful, hence the default, \code{waldo::compare()} is used to assess the output
 fidelity and doesn't check it, but if you really need to generate code that builds
-an object \code{identical()} to the input you'll need to set this to \code{TRUE}.}
+an object \code{identical()} to the input you'll need to set this to \code{TRUE}.#'}
+
+\item{recycle}{Boolean. Whether to recycle scalars to compress the output.}
 }
 \value{
 An object of class <constructive_options/constructive_options_data.table>

--- a/man/opts_tbl_df.Rd
+++ b/man/opts_tbl_df.Rd
@@ -8,7 +8,8 @@ opts_tbl_df(
   constructor = c("tibble", "tribble", "next", "list"),
   ...,
   trailing_comma = TRUE,
-  justify = c("left", "right", "centre", "none")
+  justify = c("left", "right", "centre", "none"),
+  recycle = TRUE
 )
 }
 \arguments{
@@ -20,6 +21,9 @@ opts_tbl_df(
 calls}
 
 \item{justify}{String. Justification for columns if \code{constructor} is \code{"tribble"}}
+
+\item{recycle}{Boolean. For the \code{"tibble"} constructor. Whether to recycle
+scalars to compress the output.}
 }
 \value{
 An object of class <constructive_options/constructive_options_tbl_df>

--- a/tests/testthat/_snaps/construct_diff.md
+++ b/tests/testthat/_snaps/construct_diff.md
@@ -7,8 +7,8 @@
       < list(a = head(cars, 2), b = "aaaaaa..  > list(a = head(iris, 1), b = "aaaaaa..
       @@ 1,5 @@                                @@ 1,11 @@                             
         list(                                    list(                                
-      <   a = data.frame(speed = c(4, 4), dis  >   a = data.frame(                    
-      : t = c(2, 10)),                         ~                                      
+      <   a = data.frame(speed = 4, dist = c(  >   a = data.frame(                    
+      : 2, 10)),                               ~                                      
       ~                                        >     Sepal.Length = 5.1,              
       ~                                        >     Sepal.Width = 3.5,               
       ~                                        >     Petal.Length = 1.4,              
@@ -27,8 +27,8 @@
       < list(a = head(cars, 2), b = "aaaaaa..  > list(a = head(iris, 1), b = "aaaaaa..
       @@ 1,5 @@                                @@ 1,11 @@                             
         list(                                    list(                                
-      <   a = data.frame(speed = c(4, 4), dis  >   a = data.frame(                    
-      : t = c(2, 10)),                         ~                                      
+      <   a = data.frame(speed = 4, dist = c(  >   a = data.frame(                    
+      : 2, 10)),                               ~                                      
       ~                                        >     Sepal.Length = 5.1,              
       ~                                        >     Sepal.Width = 3.5,               
       ~                                        >     Petal.Length = 1.4,              

--- a/tests/testthat/_snaps/construct_dput.md
+++ b/tests/testthat/_snaps/construct_dput.md
@@ -34,9 +34,9 @@
       data.frame(
         Sepal.Length = c(5.1, 4.9),
         Sepal.Width = c(3.5, 3),
-        Petal.Length = c(1.4, 1.4),
-        Petal.Width = c(0.2, 0.2),
-        Species = factor(c("setosa", "setosa"), levels = c("setosa", "versicolor", "virginica"))
+        Petal.Length = 1.4,
+        Petal.Width = 0.2,
+        Species = factor("setosa", levels = c("setosa", "versicolor", "virginica"))
       )
     Code
       construct(iris2, classes = "{base}")
@@ -44,9 +44,9 @@
       data.frame(
         Sepal.Length = c(5.1, 4.9),
         Sepal.Width = c(3.5, 3),
-        Petal.Length = c(1.4, 1.4),
-        Petal.Width = c(0.2, 0.2),
-        Species = factor(c("setosa", "setosa"), levels = c("setosa", "versicolor", "virginica"))
+        Petal.Length = 1.4,
+        Petal.Width = 0.2,
+        Species = factor("setosa", levels = c("setosa", "versicolor", "virginica"))
       )
     Code
       construct(iris2, classes = "-{base}")
@@ -77,9 +77,9 @@
       data.frame(
         Sepal.Length = c(5.1, 4.9),
         Sepal.Width = c(3.5, 3),
-        Petal.Length = c(1.4, 1.4),
-        Petal.Width = c(0.2, 0.2),
-        Species = c(1L, 1L) |>
+        Petal.Length = 1.4,
+        Petal.Width = 0.2,
+        Species = 1L |>
           structure(levels = c("setosa", "versicolor", "virginica"), class = "factor")
       )
     Code

--- a/tests/testthat/_snaps/encoding.md
+++ b/tests/testthat/_snaps/encoding.md
@@ -1,10 +1,11 @@
 # Encoding
 
     Code
-      construct(data.frame(x = c("ü", "a"), y = c("long_enough_for_multiline_output")))
+      construct(data.frame(x = c("ü", "a"), y = c(
+        "loooooooooooooooooooooooooooooooooong_enough_for_multiline_output")))
     Output
       data.frame(
         x = c("\U{FC}", "a"),
-        y = c("long_enough_for_multiline_output", "long_enough_for_multiline_output")
+        y = "loooooooooooooooooooooooooooooooooong_enough_for_multiline_output"
       )
 

--- a/tests/testthat/_snaps/s3-AsIs.md
+++ b/tests/testthat/_snaps/s3-AsIs.md
@@ -12,7 +12,7 @@
     Code
       construct(I(head(cars, 2)))
     Output
-      I(data.frame(speed = c(4, 4), dist = c(2, 10)))
+      I(data.frame(speed = 4, dist = c(2, 10)))
     Code
       x <- 1
       class(x) <- c("AsIs", "foo")

--- a/tests/testthat/_snaps/s3-constructive_options.md
+++ b/tests/testthat/_snaps/s3-constructive_options.md
@@ -20,5 +20,5 @@
     Code
       construct(opts_data.frame("read.table"))
     Output
-      constructive::opts_data.frame("read.table")
+      constructive::opts_data.frame("read.table", recycle = TRUE)
 

--- a/tests/testthat/_snaps/s3-data.frame.md
+++ b/tests/testthat/_snaps/s3-data.frame.md
@@ -3,22 +3,22 @@
     Code
       construct(head(cars, 2))
     Output
-      data.frame(speed = c(4, 4), dist = c(2, 10))
+      data.frame(speed = 4, dist = c(2, 10))
     Code
       construct(head(mtcars, 2))
     Output
       data.frame(
-        mpg = c(21, 21),
-        cyl = c(6, 6),
-        disp = c(160, 160),
-        hp = c(110, 110),
-        drat = c(3.9, 3.9),
+        mpg = 21,
+        cyl = 6,
+        disp = 160,
+        hp = 110,
+        drat = 3.9,
         wt = c(2.62, 2.875),
         qsec = c(16.46, 17.02),
-        vs = c(0, 0),
-        am = c(1, 1),
-        gear = c(4, 4),
-        carb = c(4, 4),
+        vs = 0,
+        am = 1,
+        gear = 4,
+        carb = 4,
         row.names = c("Mazda RX4", "Mazda RX4 Wag")
       )
     Code
@@ -56,9 +56,9 @@
       data.frame(
         Sepal.Length = c(5.1, 4.9),
         Sepal.Width = c(3.5, 3),
-        Petal.Length = c(1.4, 1.4),
-        Petal.Width = c(0.2, 0.2),
-        Species = factor(c("setosa", "setosa"), levels = c("setosa", "versicolor", "virginica"))
+        Petal.Length = 1.4,
+        Petal.Width = 0.2,
+        Species = factor("setosa", levels = c("setosa", "versicolor", "virginica"))
       )
     Code
       construct(data.frame(a = 1:2, b = 3:4)[2, ], opts_data.frame("read.table"))
@@ -84,13 +84,13 @@
         1, NA)))
     Output
       data.frame(
-        a = c(NA, NA),
+        a = NA,
         b = c(TRUE, NA),
-        c = c(NA_character_, NA_character_),
+        c = NA_character_,
         d = c("a", NA),
-        e = c(NA_integer_, NA_integer_),
+        e = NA_integer_,
         f = c(1L, NA),
-        g = c(NA_real_, NA_real_),
+        g = NA_real_,
         h = c(1, NA)
       )
     Code
@@ -129,4 +129,30 @@
       construct(data.frame(row.names = c("a", "b")))
     Output
       data.frame(row.names = c("a", "b"))
+
+# recycle in data frames
+
+    Code
+      construct(data.frame(a = 1:2, b = c(1, 1)))
+    Output
+      data.frame(a = 1:2, b = 1)
+    Code
+      construct(data.frame(a = c(1, 1), b = c(1, 1)))
+    Output
+      data.frame(a = c(1, 1), b = 1)
+    Code
+      construct(data.frame(a = 1:2, b = factor(c("a", "a"))))
+    Output
+      data.frame(a = 1:2, b = factor("a"))
+    Code
+      construct(data.frame(a = 1:2, b = as.Date(c("2000-01-01", "2000-01-01"))))
+    Output
+      data.frame(a = 1:2, b = as.Date("2000-01-01"))
+
+# duplicate names in data frames
+
+    Code
+      construct(data.frame(a = 1, a = 2, check.names = FALSE))
+    Output
+      data.frame(a = 1, a = 2, check.names = FALSE)
 

--- a/tests/testthat/_snaps/s3-data.table.md
+++ b/tests/testthat/_snaps/s3-data.table.md
@@ -4,16 +4,16 @@
       dt1 <- data.table::data.table(head(cars, 2))
       construct(dt1)
     Output
-      data.table::data.table(speed = c(4, 4), dist = c(2, 10))
+      data.table::data.table(speed = 4, dist = c(2, 10))
     Code
       construct(dt1, opts_data.table(selfref = TRUE))
     Output
-      data.table::data.table(speed = c(4, 4), dist = c(2, 10)) |>
+      data.table::data.table(speed = 4, dist = c(2, 10)) |>
         structure(.internal.selfref = constructive::.xptr("0x123456789"))
     Code
       construct(dt1, opts_data.table("next"))
     Output
-      data.frame(speed = c(4, 4), dist = c(2, 10)) |>
+      data.frame(speed = 4, dist = c(2, 10)) |>
         structure(
           class = c("data.table", "data.frame"),
           .internal.selfref = constructive::.xptr("0x123456789")
@@ -31,5 +31,32 @@
       dt2 <- data.table::data.table(dt1, key = "speed")
       construct(dt2)
     Output
-      data.table::data.table(speed = c(4, 4), dist = c(2, 10), key = "speed")
+      data.table::data.table(speed = 4, dist = c(2, 10), key = "speed")
+
+# recycle in data tables
+
+    Code
+      construct(data.table::data.table(a = 1:2, b = c(1, 1)))
+    Output
+      data.table::data.table(a = 1:2, b = 1)
+    Code
+      construct(data.table::data.table(a = c(1, 1), b = c(1, 1)))
+    Output
+      data.table::data.table(a = c(1, 1), b = 1)
+    Code
+      construct(data.table::data.table(a = 1:2, b = factor(c("a", "a"))))
+    Output
+      data.table::data.table(a = 1:2, b = factor("a"))
+    Code
+      construct(data.table::data.table(a = 1:2, b = as.Date(c("2000-01-01",
+        "2000-01-01"))))
+    Output
+      data.table::data.table(a = 1:2, b = as.Date("2000-01-01"))
+
+# duplicate names in data tables
+
+    Code
+      construct(data.table::data.table(a = 1, a = 2))
+    Output
+      data.table::data.table(a = 1, a = 2)
 

--- a/tests/testthat/_snaps/s3-dm.md
+++ b/tests/testthat/_snaps/s3-dm.md
@@ -4,7 +4,7 @@
       construct(dm::dm(cars1 = head(cars, 2), cars2 = tail(cars, 2)), check = FALSE)
     Output
       dm::dm(
-        cars1 = data.frame(speed = c(4, 4), dist = c(2, 10)),
+        cars1 = data.frame(speed = 4, dist = c(2, 10)),
         cars2 = data.frame(speed = c(24, 25), dist = c(120, 85), row.names = 49:50),
       )
     Code

--- a/tests/testthat/_snaps/s3-grouped_df.md
+++ b/tests/testthat/_snaps/s3-grouped_df.md
@@ -3,6 +3,6 @@
     Code
       construct(dplyr::group_by(head(cars, 2), dist))
     Output
-      tibble::tibble(speed = c(4, 4), dist = c(2, 10)) |>
+      tibble::tibble(speed = 4, dist = c(2, 10)) |>
         dplyr::group_by(dist)
 

--- a/tests/testthat/_snaps/s3-rowwise_df.md
+++ b/tests/testthat/_snaps/s3-rowwise_df.md
@@ -3,11 +3,11 @@
     Code
       construct(dplyr::rowwise(head(cars, 2)))
     Output
-      tibble::tibble(speed = c(4, 4), dist = c(2, 10)) |>
+      tibble::tibble(speed = 4, dist = c(2, 10)) |>
         dplyr::rowwise()
     Code
       construct(dplyr::rowwise(head(cars, 2), dist))
     Output
-      tibble::tibble(speed = c(4, 4), dist = c(2, 10)) |>
+      tibble::tibble(speed = 4, dist = c(2, 10)) |>
         dplyr::rowwise(dist)
 

--- a/tests/testthat/_snaps/s3-tbl_df.md
+++ b/tests/testthat/_snaps/s3-tbl_df.md
@@ -57,3 +57,29 @@
         ),
       )
 
+# recycle in tibbles
+
+    Code
+      construct(tibble::tibble(a = 1:2, b = c(1, 1)))
+    Output
+      tibble::tibble(a = 1:2, b = 1)
+    Code
+      construct(tibble::tibble(a = c(1, 1), b = c(1, 1)))
+    Output
+      tibble::tibble(a = 1, b = 1, .rows = 2L)
+    Code
+      construct(tibble::tibble(a = 1:2, b = factor(c("a", "a"))))
+    Output
+      tibble::tibble(a = 1:2, b = factor("a"))
+    Code
+      construct(tibble::tibble(a = 1:2, b = as.Date(c("2000-01-01", "2000-01-01"))))
+    Output
+      tibble::tibble(a = 1:2, b = as.Date("2000-01-01"))
+
+# duplicate names in tibbles
+
+    Code
+      construct(tibble::tibble(a = 1, a = 2, .name_repair = "minimal"))
+    Output
+      tibble::tibble(a = 1, a = 2, .name_repair = "minimal")
+

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -2,7 +2,7 @@ test_that("Encoding", {
   expect_snapshot(
     construct(data.frame(
       x = c("ü","a"),
-      y = c("long_enough_for_multiline_output")
+      y = c("loooooooooooooooooooooooooooooooooong_enough_for_multiline_output")
     ))
   )
 })

--- a/tests/testthat/test-s3-data.frame.R
+++ b/tests/testthat/test-s3-data.frame.R
@@ -51,5 +51,17 @@ test_that("data.frame", {
   })
 })
 
-# -------------------------------------------------------------------------
+test_that("recycle in data frames", {
+  expect_snapshot({
+    construct(data.frame(a = 1:2, b = c(1, 1)))
+    construct(data.frame(a = c(1, 1), b = c(1, 1)))
+    construct(data.frame(a = 1:2, b = factor(c("a", "a"))))
+    construct(data.frame(a = 1:2, b = as.Date(c("2000-01-01", "2000-01-01"))))
+  })
+})
 
+test_that("duplicate names in data frames", {
+  expect_snapshot({
+    construct(data.frame(a = 1, a =2, check.names = FALSE))
+  })
+})

--- a/tests/testthat/test-s3-data.table.R
+++ b/tests/testthat/test-s3-data.table.R
@@ -10,3 +10,18 @@ test_that("data.table", {
     construct(dt2)
   })
 })
+
+test_that("recycle in data tables", {
+  expect_snapshot({
+    construct(data.table::data.table(a = 1:2, b = c(1, 1)))
+    construct(data.table::data.table(a = c(1, 1), b = c(1, 1)))
+    construct(data.table::data.table(a = 1:2, b = factor(c("a", "a"))))
+    construct(data.table::data.table(a = 1:2, b = as.Date(c("2000-01-01", "2000-01-01"))))
+  })
+})
+
+test_that("duplicate names in data tables", {
+  expect_snapshot({
+    construct(data.table::data.table(a = 1, a =2))
+  })
+})

--- a/tests/testthat/test-s3-tbl_df.R
+++ b/tests/testthat/test-s3-tbl_df.R
@@ -17,3 +17,18 @@ test_that("tbl_df with `tribble = TRUE` falls back on tibble() if unsupported co
     construct(tibble::tibble(a = 1:2, b = tibble::tibble(x = 3:4)), opts_tbl_df(constructor = "tribble"))
   })
 })
+
+test_that("recycle in tibbles", {
+  expect_snapshot({
+    construct(tibble::tibble(a = 1:2, b = c(1, 1)))
+    construct(tibble::tibble(a = c(1, 1), b = c(1, 1)))
+    construct(tibble::tibble(a = 1:2, b = factor(c("a", "a"))))
+    construct(tibble::tibble(a = 1:2, b = as.Date(c("2000-01-01", "2000-01-01"))))
+  })
+})
+
+test_that("duplicate names in tibbles", {
+  expect_snapshot({
+    construct(tibble::tibble(a = 1, a =2, .name_repair = "minimal"))
+  })
+})


### PR DESCRIPTION
Closes #470 
This will unfortunately break some valid snapshot tests but I think it's better to have this the default behavior. There is a `recycle = TRUE` arg to `opts_data.frame()`, `opts_tbl_df()`, `opts_data.table()` if this needs to be turned off (in that case this needs to be turned of individually for these various classes.

Since recycling relies on S3 subsetting we cannot guarantee that it works if we don't know the bracket method, so I made it work only for the main base classes. The list of supported classes can be extended however.