### PR TITLE
feat: show a console message when using construct_clip()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,16 +1,12 @@
 Package: constructive
 Title: Display Idiomatic Code to Construct Most R Objects
 Version: 1.0.1.9000
-Authors@R: 
-    c(person(given = "Antoine",
-             family = "Fabri",
-             email = "antoine.fabri@gmail.com",
-             role = c("aut", "cre")),
-      person(given = "Kirill",
-       family = "Müller",
-       role = "ctb",
-       email = "kirill@cynkra.com",
-       comment = c(ORCID = "0000-0002-1416-3412")))
+Authors@R: c(
+    person("Antoine", "Fabri", , "antoine.fabri@gmail.com", role = c("aut", "cre")),
+    person("Kirill", "Müller", , "kirill@cynkra.com", role = "ctb",
+           comment = c(ORCID = "0000-0002-1416-3412")),
+    person("Jacob", "Scott", , "jscott2718@gmail.com", role = "ctb")
+  )
 Description: Prints code that can be used to recreate R objects. In a
     sense it is similar to 'base::dput()' or 'base::deparse()' but
     'constructive' strives to use idiomatic constructors.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # constructive (development version)
 
+* `construct_clip()` now shows a console message in addition to writing to the
+  clipboard
+
 # constructive 1.0.1
 
 * We fixed a typo that was breaking `.cstr_new_class(, commented = TRUE)`

--- a/R/construct.R
+++ b/R/construct.R
@@ -282,6 +282,12 @@ print.constructive <- function(
     multiple = TRUE
   )
 
+  if ("clipboard" %in% print_mode) {
+    check_installed("clipr")
+    cli::cli_alert_info("Construct code has been added to the clipboard:")
+    clipr::write_clip(paste(x$code, collapse = "\n"), "character")
+    print_mode <- union(print_mode, "console")
+  }
   if ("console" %in% print_mode) {
     print(x$code)
   }
@@ -289,10 +295,6 @@ print.constructive <- function(
     check_installed("reprex")
     reprex_code <- c('getFromNamespace("prex", "reprex")({', x$code, "})")
     eval.parent(parse(text = reprex_code))
-  }
-  if ("clipboard" %in% print_mode) {
-    check_installed("clipr")
-    clipr::write_clip(paste(x$code, collapse = "\n"), "character")
   }
   if ("script" %in% print_mode) {
     check_installed("rstudioapi")


### PR DESCRIPTION
Closes #486 

NB, I had some test failures when running locally, but I think they must be due to differences with my setup because they were all about where linebreaks are placed. Here's an example:

```
Failure ([test-s3-R6ClassGenerator.R:2:3](vscode-file://vscode-app/Applications/Positron.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html#)): R6Class
Snapshot of code has changed:
     old                                                        | new                                                  
[54]     ),                                                     |     ),                                           [54]
[55]     private = list(                                        |     private = list(                              [55]
[56]       queue = list(),                                      |       queue = list(),                            [56]
[57]       length = (function() base::length(private$queue)) |> -       length = (function() base::length(private$ [57]
                                                                -         queue)) |>                               [58]
[58]         (`environment<-`)(                                 |         (`environment<-`)(                       [59]
[59]           constructive::.env(                              |           constructive::.env(                    [60]
[60]             "0x123456789",                                 |             "0x123456789",                       [61]
```

I assume these won't show up in the CI tests. I'll investigate further when I get a chance.