### PR TITLE
construct_clip respects non default print modes

### DIFF
--- a/R/construct.R
+++ b/R/construct.R
@@ -284,9 +284,8 @@ print.constructive <- function(
 
   if ("clipboard" %in% print_mode) {
     check_installed("clipr")
-    cli::cli_alert_info("Construct code has been added to the clipboard:")
+    cli::cli_alert_info("Code has been added to the clipboard")
     clipr::write_clip(paste(x$code, collapse = "\n"), "character")
-    print_mode <- union(print_mode, "console")
   }
   if ("console" %in% print_mode) {
     print(x$code)

--- a/R/construct_clip.R
+++ b/R/construct_clip.R
@@ -39,5 +39,5 @@ construct_clip <- function(
     template = template,
     classes = classes
   )
-  print(out, print_mode = "clipboard")
+  print(out, print_mode = union("clipboard", getOption("constructive_print_mode", "console")))
 }

--- a/man/constructive-package.Rd
+++ b/man/constructive-package.Rd
@@ -25,6 +25,7 @@ Useful links:
 Other contributors:
 \itemize{
   \item Kirill Müller \email{kirill@cynkra.com} (\href{https://orcid.org/0000-0002-1416-3412}{ORCID}) [contributor]
+  \item Jacob Scott \email{jscott2718@gmail.com} [contributor]
 }
 
 }


### PR DESCRIPTION
Improves on #488 