### PR TITLE
Use skip_if_not_installed consistently

### DIFF
--- a/tests/testthat/test-s3-xts.R
+++ b/tests/testthat/test-s3-xts.R
@@ -1,5 +1,5 @@
 test_that("xts", {
-  skip_if(!is_installed("xts"))
+  skip_if_not_installed("xts")
   # xts object convert character dates to POSIXct with local timezone, needs
   # to be stabilized for the CI tests
   withr::local_timezone("UTC")


### PR DESCRIPTION
This will also foster consistency in the output logs, c.f.

````
• {forcats} is not installed (1): test-s3-factor.R:2:3
• {ggplot2} is not installed (10): test-s3-ggplot2-Coord.R:2:3,
  test-s3-ggplot2-Coord.R:10:3, test-s3-ggplot2-Coord.R:19:3,
  test-s3-ggplot2-Coord.R:25:3, test-s3-ggplot2-Coord.R:35:3,
  test-s3-ggplot2-Coord.R:51:5, test-s3-ggplot2-labels.R:2:3,
  test-s3-ggplot2-Scale.R:2:3, test-s3-ggplot2-theme.R:2:3,
  test-s3-ggplot2-waiver.R:2:3
• !is_installed("xts") is TRUE (1): test-s3-xts.R:2:3
• {lubridate} is not installed (2): test-s3-Date.R:15:3, test-s3-POSIXct.R:62:3
```