### PR TITLE
Streamline #includes

### DIFF
--- a/src/constructive.c
+++ b/src/constructive.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <inttypes.h> // for SCNxPTR
 #include <stdlib.h> // for NULL
-#include <R_ext/error.h> // for error
+#include <R_ext/Error.h> // for error
 #include <R_ext/Rdynload.h>
 
 /* .Call calls */

--- a/src/constructive.c
+++ b/src/constructive.c
@@ -3,7 +3,7 @@
 #include <stdint.h> // for uintptr_t
 #include <stdio.h>
 #include <stdlib.h> // for NULL
-#include <R_ext/error.h> // for error
+#include <R_ext/Error.h> // for error
 #include <R_ext/Rdynload.h>
 
 /* .Call calls */

--- a/src/constructive.c
+++ b/src/constructive.c
@@ -2,6 +2,7 @@
 #include <Rdefines.h>
 #include <stdint.h> // for uintptr_t
 #include <stdio.h>
+#include <inttypes.h> // for SCNxPTR
 #include <stdlib.h> // for NULL
 #include <R_ext/Error.h> // for error
 #include <R_ext/Rdynload.h>

--- a/src/constructive.c
+++ b/src/constructive.c
@@ -1,9 +1,9 @@
-#include <R.h>
 #include <Rinternals.h>
 #include <Rdefines.h>
+#include <stdint.h> // for uintptr_t
 #include <stdio.h>
-#include <inttypes.h>
 #include <stdlib.h> // for NULL
+#include <R_ext/error.h> // for error
 #include <R_ext/Rdynload.h>
 
 /* .Call calls */

--- a/src/constructive.c
+++ b/src/constructive.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <inttypes.h> // for SCNxPTR
 #include <stdlib.h> // for NULL
-#include <R_ext/Error.h> // for error
+#include <R_ext/error.h> // for error
 #include <R_ext/Rdynload.h>
 
 /* .Call calls */


### PR DESCRIPTION
As flagged by `clang-tidy`:

https://clang.llvm.org/extra/clang-tidy/checks/misc/include-cleaner.html

Usually I ignore these recommendations for R packages, but the C code here is self-contained enough that the change is easier to motivate.