### PR TITLE
stabilize snapshot

### DIFF
--- a/tests/testthat/_snaps/s3-language.md
+++ b/tests/testthat/_snaps/s3-language.md
@@ -9,14 +9,10 @@
     Output
       quote(a + call)
     Code
-      construct(body(ave))
+      construct(body(as_constructive_code))
     Output
       quote({
-        if (missing(...)) x[] <- FUN(x) else {
-          g <- interaction(...)
-          split(x, g) <- lapply(split(x, g), FUN)
-        }
-        x
+        structure(x, class = "constructive_code")
       })
     Code
       construct(quote(expr = ))

--- a/tests/testthat/test-s3-language.R
+++ b/tests/testthat/test-s3-language.R
@@ -2,7 +2,7 @@ test_that("language", {
   expect_snapshot({
     construct(quote(a_symbol))
     construct(quote(a + call))
-    construct(body(ave))
+    construct(body(as_constructive_code))
     construct(quote(expr=))
   })
 })


### PR DESCRIPTION
We snapshot a constructive function rather than ave.
This was not very wise to snapshot ave, this will break the package if a new R version is release before a new constructive version.