### PR TITLE
Handle ellmer >= 0.4.2 deprecation of `type_object(.additional_properties)`

### DIFF
--- a/R/s7-elmer_TypeObject.R
+++ b/R/s7-elmer_TypeObject.R
@@ -30,10 +30,8 @@ opts_ellmer_TypeObject <- function(constructor = c("type_object", "TypeObject", 
   args <- c(
     list(.description = attr(x, "description")),
     attr(x, "properties"),
-    list(
-      .required = attr(x, "required"),
-      .additional_properties = attr(x, "additional_properties")
-    )
+    list(.required = attr(x, "required")),
+    if (with_versions(ellmer < "0.4.2")) list(.additional_properties = attr(x, "additional_properties"))
   )
   args <- keep_only_non_defaults(args, ellmer::type_object)
   names(args)[names(args) == ".description"] <- ""

--- a/tests/testthat/test-s7-elmer_TypeBasic.R
+++ b/tests/testthat/test-s7-elmer_TypeBasic.R
@@ -10,20 +10,6 @@ test_that("ellmer::TypeBasic", {
       )
     )
   )
-  expect_construct(
-    ellmer::type_array(
-      "An array",
-      items = ellmer::type_object(
-        "An object",
-        x = ellmer::type_boolean("A boolean", required = FALSE),
-        y = ellmer::type_string("A string"),
-        z = ellmer::type_number("A number"),
-        json = ellmer::type_from_schema("[1,2]"),
-        .additional_properties = TRUE
-      ),
-      required = FALSE
-    )
-  )
 })
 
 test_that("ellmer::TypeBasic v <= 0.2.1", {
@@ -91,9 +77,9 @@ test_that("ellmer::TypeBasic v <= 0.2.1", {
   )
 })
 
-test_that("ellmer::TypeBasic v > 0.2.1", {
+test_that("ellmer::TypeBasic v > 0.2.1 and v < 0.4.2", {
   skip_if_not_installed("ellmer")
-  skip_if(with_versions(ellmer <= "0.2.1"))
+  skip_if(with_versions(ellmer <= "0.2.1" || ellmer >= "0.4.2"))
 
   # from o.3.0 .additional_properties in type_object() and
   # additional_properties in TypeObject() both default to FALSE

--- a/tests/testthat/test-s7-elmer_TypeBasic.R
+++ b/tests/testthat/test-s7-elmer_TypeBasic.R
@@ -10,6 +10,19 @@ test_that("ellmer::TypeBasic", {
       )
     )
   )
+  expect_construct(
+    ellmer::type_array(
+      "An array",
+      items = ellmer::type_object(
+        "An object",
+        x = ellmer::type_boolean("A boolean", required = FALSE),
+        y = ellmer::type_string("A string"),
+        z = ellmer::type_number("A number"),
+        json = ellmer::type_from_schema("[1,2]")
+      ),
+      required = FALSE
+    )
+  )
 })
 
 test_that("ellmer::TypeBasic v <= 0.2.1", {


### PR DESCRIPTION
Fixes #664 

ellmer 0.4.2 deprecates the `.additional_properties` argument to `type_object()`. This PR updates the `type_object` constructor to only include `.additional_properties` on older ellmer versions, and version-gates the corresponding tests.